### PR TITLE
Put iconloaderfix into own namespace

### DIFF
--- a/qiconfix/qiconloader.cpp
+++ b/qiconfix/qiconloader.cpp
@@ -74,7 +74,7 @@
 #include <limits.h>
 #endif
 
-QT_BEGIN_NAMESPACE
+namespace QtXdg {
 
 Q_GLOBAL_STATIC(QIconLoader, iconLoaderInstance)
 
@@ -704,6 +704,6 @@ void QIconLoaderEngineFixed::virtual_hook(int id, void *data)
     }
 }
 
-QT_END_NAMESPACE
+} // QtXdg
 
 #endif //QT_NO_ICON

--- a/qiconfix/qiconloader_p.h
+++ b/qiconfix/qiconloader_p.h
@@ -75,7 +75,7 @@
 //#include "qt/qfactoryloader_p.h"
 #include <QHash>
 
-QT_BEGIN_NAMESPACE
+namespace QtXdg {
 
 class QIconLoader;
 
@@ -209,7 +209,7 @@ private:
     mutable QHash <QString, QIconTheme> themeList;
 };
 
-QT_END_NAMESPACE
+} // QtXdg
 
 #endif // QDESKTOPICON_P_H
 

--- a/xdgicon.cpp
+++ b/xdgicon.cpp
@@ -95,7 +95,7 @@ QString XdgIcon::themeName()
 void XdgIcon::setThemeName(const QString& themeName)
 {
     QIcon::setThemeName(themeName);
-    QIconLoader::instance()->updateSystemTheme();
+    QtXdg::QIconLoader::instance()->updateSystemTheme();
 }
 
 
@@ -125,7 +125,7 @@ QIcon XdgIcon::fromTheme(const QString& iconName, const QIcon& fallback)
     } else {
         QIcon *cachedIcon;
         if (!isAbsolute)
-            cachedIcon = new QIcon(new QIconLoaderEngineFixed(name));
+            cachedIcon = new QIcon(new QtXdg::QIconLoaderEngineFixed(name));
         else
             cachedIcon = new QIcon(iconName);
         qtIconCache()->insert(name, cachedIcon);


### PR DESCRIPTION
In Qt5.2 it looks like a private property of QIconTheme went missing so the classes no longer line up.  This causes a VERY odd crash when you load an icon via the XdgIcon::fromTheme(...) since it tries to copy the QIconTheme and m_contentDirs is missing.  The order changed so memory is 7 colors of screwed up.

This patch puts the fixed loader into its own QtXdg namespace to keep the classes isolated and intended operation correct.
