### PR TITLE
Set genericName as tooltip

### DIFF
--- a/qtxdg/xdgaction.h
+++ b/qtxdg/xdgaction.h
@@ -71,9 +71,11 @@ public:
 
     const XdgDesktopFile& desktopFile() const { return mDesktopFile; }
 
+public Q_SLOTS:
+    void updateIcon();
+
 private Q_SLOTS:
     void runConmmand() const;
-    void updateIcon();
 
 private:
     void load(const XdgDesktopFile& desktopFile);

--- a/qtxdg/xdgmenuwidget.cpp
+++ b/qtxdg/xdgmenuwidget.cpp
@@ -105,7 +105,8 @@ void XdgMenuWidgetPrivate::init(const QDomElement& xml)
         title = xml.attribute(QLatin1String("name"));
     q->setTitle(escape(title));
 
-    q->setToolTip(xml.attribute(QLatin1String("comment")));
+    //q->setToolTip(xml.attribute(QLatin1String("comment")));
+    q->setToolTipsVisible(true);
 
 
     QIcon parentIcon;
@@ -221,12 +222,12 @@ XdgAction* XdgMenuWidgetPrivate::createAction(const QDomElement& xml)
     else
         title = xml.attribute(QLatin1String("name"));
 
+    action->setText(escape(title));
 
     if (!xml.attribute(QLatin1String("genericName")).isEmpty() &&
          xml.attribute(QLatin1String("genericName")) != title)
-        title += QString::fromLatin1(" (%1)").arg(xml.attribute(QLatin1String("genericName")));
+        action->setToolTip(xml.attribute(QLatin1String("genericName")));
 
-    action->setText(escape(title));
     return action;
 }
 


### PR DESCRIPTION
... instead of making a long action text with it.

Also, `XdgAction::updateIcon()` may be needed to be called in codes, as is the case with LXQt's main menu for showing icons in the search view (a PR will follow this for it).