### PR TITLE
xdgaction: Remove unneeded processEvents() call

### DIFF
--- a/qtxdg/xdgaction.cpp
+++ b/qtxdg/xdgaction.cpp
@@ -118,5 +118,4 @@ void XdgAction::updateIcon()
     setIcon(mDesktopFile.icon());
     if (icon().isNull())
         setIcon(XdgIcon::fromTheme(QLatin1String("application-x-executable")));
-    QCoreApplication::processEvents();
 }


### PR DESCRIPTION
..as it can lead to unwanted recurrency and cause segfaults.

E.g.: lxqt-panel mainmenu searching:
 (0x7ffe4effb0e0) Warning: QWidget::repaint: Recursive repaint detected
 (0x7ffe4effb0e0) Warning: QWidget::paintEngine: Should no longer be called
 (0x7ffe4effb0e0) Warning: QPainter::begin: Paint device returned engine == 0, type: 1
 (0x7ffe4effb0e0) Warning: QPainter::save: Painter not active
 (0x7ffe4effb0e0) Warning: QPainter::setPen: Painter not active
 (0x7ffe4effb0e0) Warning: QPainter::drawRects: Painter not active
 (0x7ffe4effb0e0) Warning: QPainter::restore: Unbalanced save/restore