### PR TITLE
Adds Qt Strings abbreviations macros

### DIFF
--- a/src/qtxdg/xdgmacros.h
+++ b/src/qtxdg/xdgmacros.h
@@ -42,4 +42,20 @@
 #    define QTXDG_AUTOTEST               /* Building library, tests disabled */
 #endif
 
+#ifndef QL1S
+#define QL1S(x) QLatin1String(x)
+#endif
+
+#ifndef QL1C
+#define QL1C(x) QLatin1Char(x)
+#endif
+
+#ifndef QSL
+#define QSL(x) QStringLiteral(x)
+#endif
+
+#ifndef QBAL
+#define QBAL(x) QByteArrayLiteral(x)
+#endif
+
 #endif // QTXDG_MACROS_H


### PR DESCRIPTION
    It reduces the clutter. Ex: instead of writing:
    ```if (node.hasAttribute(QStringLiteral("http-contents-length")))```
    just write:
    ```if (node.hasAttribute(QSL("http-contents-length")))```