### PR TITLE
Adds a MIME Applications Associations (XdgMimeApps) class and companion tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,11 @@ set(QTXDG_VERSION_STRING ${QTXDG_MAJOR_VERSION}.${QTXDG_MINOR_VERSION}.${QTXDG_P
 
 set(LXQTBT_MINIMUM_VERSION "0.6.0")
 set(QT_MINIMUM_VERSION "5.7.1")
+set(GLIB_MINIMUM_VERSION "2.41.0") # Mime Apps new implementation
 
 find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5 ${QT_MINIMUM_VERSION} CONFIG REQUIRED Widgets Svg Xml DBus)
+find_package(GLIB ${GLIB_MINIMUM_VERSION} REQUIRED COMPONENTS gobject gio gio-unix)
 
 include(GNUInstallDirs)             # Standard directories for installation
 include(CMakePackageConfigHelpers)

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -53,16 +53,6 @@
 #-----------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------
-# String conversion flags
-#-----------------------------------------------------------------------------
-add_definitions(
-    -DQT_NO_CAST_FROM_ASCII
-    -DQT_NO_CAST_TO_ASCII
-    -DQT_NO_URL_CAST_FROM_STRING
-    -DQT_NO_CAST_FROM_BYTEARRAY
-)
-
-#-----------------------------------------------------------------------------
 # Turn on more aggrassive optimizations not supported by CMake
 # References: https://wiki.qt.io/Performance_Tip_Startup_Time
 #-----------------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(xdgiconloader)
 add_subdirectory(qtxdg)
+add_subdirectory(tools)

--- a/src/qtxdg/CMakeLists.txt
+++ b/src/qtxdg/CMakeLists.txt
@@ -13,6 +13,7 @@ set(libqtxdg_PUBLIC_H_FILES
     xdgautostart.h
     xdgmacros.h
     xdgmimetype.h
+    xdgmimeapps.h
 )
 
 set(libqtxdg_PUBLIC_CLASSES
@@ -25,18 +26,22 @@ set(libqtxdg_PUBLIC_CLASSES
     XmlHelper
     XdgAutoStart
     XdgMimeType
+    XdgMimeApps
 )
 
 set(libqtxdg_PRIVATE_H_FILES
+    qtxdglogging.h
     xdgmenuapplinkprocessor.h
     xdgmenulayoutprocessor.h
     xdgmenu_p.h
     xdgmenureader.h
     xdgmenurules.h
     xdgdesktopfile_p.h
+    xdgmimeapps_p.h
 )
 
 set(libqtxdg_CPP_FILES
+    qtxdglogging.cpp
     xdgaction.cpp
     xdgdesktopfile.cpp
     xdgdirs.cpp
@@ -50,6 +55,9 @@ set(libqtxdg_CPP_FILES
     xmlhelper.cpp
     xdgautostart.cpp
     xdgmimetype.cpp
+    xdgmimeapps.cpp
+    xdgmimeappsbackendinterface.cpp
+    xdgmimeappsglibbackend.cpp
 )
 
 QT5_ADD_DBUS_INTERFACE(libqtxdg_DBUS_INTERFACE_SRCS
@@ -70,6 +78,9 @@ target_link_libraries(${QTXDGX_LIBRARY_NAME}
     PUBLIC
         ${QTX_LIBRARIES}
         ${QTXDGX_ICONLOADER_LIBRARY_NAME}
+        ${GLIB_LIBRARIES}
+        ${GLIB_GOBJECT_LIBRARIES}
+        ${GLIB_GIO_LIBRARIES}
 )
 
 set_target_properties(${QTXDGX_LIBRARY_NAME} PROPERTIES
@@ -92,6 +103,8 @@ target_include_directories(${QTXDGX_LIBRARY_NAME}
         "$<BUILD_INTERFACE:${QTXDGX_INTREE_INCLUDEDIR}>"
     PRIVATE
         ${Qt5Gui_PRIVATE_INCLUDE_DIRS}
+        ${GLIB_INCLUDE_DIRS}
+        ${GLIB_GIO_UNIX_INCLUDE_DIR}
 )
 
 # create the portble headers

--- a/src/qtxdg/qtxdglogging.cpp
+++ b/src/qtxdg/qtxdglogging.cpp
@@ -1,0 +1,31 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#include "qtxdglogging.h"
+
+#include <QtGlobal>
+
+#if defined(NDEBUG)
+Q_LOGGING_CATEGORY(QtXdgMimeApps, "qtxdg.mimeapps", QtInfoMsg)
+Q_LOGGING_CATEGORY(QtXdgMimeAppsGLib, "qtxdg.mimeapps.glib", QtInfoMsg)
+#else
+Q_LOGGING_CATEGORY(QtXdgMimeApps, "qtxdg.mimeapps")
+Q_LOGGING_CATEGORY(QtXdgMimeAppsGLib, "qtxdg.mimeapps.glib")
+#endif

--- a/src/qtxdg/qtxdglogging.h
+++ b/src/qtxdg/qtxdglogging.h
@@ -1,0 +1,29 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#ifndef QTXDGLOGGING_H
+#define QTXDGLOGGING_H
+
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(QtXdgMimeApps)
+Q_DECLARE_LOGGING_CATEGORY(QtXdgMimeAppsGLib)
+
+#endif // QTXDGLOGGING_H

--- a/src/qtxdg/xdgdesktopfile.cpp
+++ b/src/qtxdg/xdgdesktopfile.cpp
@@ -31,6 +31,7 @@
 #include "xdgdirs.h"
 #include "xdgicon.h"
 #include "application_interface.h" // generated interface for DBus org.freedesktop.Application
+#include "xdgmimeapps.h"
 
 #include <cstdlib>
 #include <unistd.h>
@@ -524,8 +525,9 @@ bool XdgDesktopFileData::startLinkDetached(const XdgDesktopFile *q) const
         QFileInfo fi(url);
 
         QMimeDatabase db;
+        XdgMimeApps appsDb;
         QMimeType mimeInfo = db.mimeTypeForFile(fi);
-        XdgDesktopFile* desktopFile = XdgDesktopFileCache::getDefaultApp(mimeInfo.name());
+        XdgDesktopFile* desktopFile = appsDb.defaultApp(mimeInfo.name());
 
         if (desktopFile)
             return desktopFile->startDetached(url);

--- a/src/qtxdg/xdgdesktopfile.h
+++ b/src/qtxdg/xdgdesktopfile.h
@@ -258,7 +258,7 @@ private:
 typedef QList<XdgDesktopFile> XdgDesktopFileList;
 
 
-class QTXDG_API XdgDesktopFileCache
+class QTXDG_API QTXDG_DEPRECATED XdgDesktopFileCache
 {
 public:
     static XdgDesktopFile* getFile(const QString& fileName);

--- a/src/qtxdg/xdgmenuapplinkprocessor.cpp
+++ b/src/qtxdg/xdgmenuapplinkprocessor.cpp
@@ -192,8 +192,8 @@ void XdgMenuApplinkProcessor::findDesktopFiles(const QString& dirName, const QSt
 
     for (const QFileInfo &file : files)
     {
-        XdgDesktopFile* f = XdgDesktopFileCache::getFile(file.canonicalFilePath());
-        if (f)
+        XdgDesktopFile *f = new XdgDesktopFile;
+        if (f->load(file.canonicalFilePath()) && f->isValid())
             mAppFileInfoHash.insert(prefix + file.fileName(), new XdgMenuAppFileInfo(f, prefix + file.fileName(), this));
     }
 

--- a/src/qtxdg/xdgmimeapps.cpp
+++ b/src/qtxdg/xdgmimeapps.cpp
@@ -1,0 +1,165 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#include "xdgmimeapps.h"
+#include "xdgmimeapps_p.h"
+
+#include "xdgdesktopfile.h"
+#include "xdgmacros.h"
+#include "xdgmimeappsglibbackend.h"
+
+#include <QMutexLocker>
+#include <QDebug>
+
+XdgMimeAppsPrivate::XdgMimeAppsPrivate()
+    : mBackend(nullptr)
+{
+}
+
+void XdgMimeAppsPrivate::init()
+{
+    Q_Q(XdgMimeApps);
+    mBackend = new XdgMimeAppsGLibBackend(q);
+    QObject::connect(mBackend, &XdgMimeAppsBackendInterface::changed, q, [=] () {
+        Q_EMIT q->changed();
+    });
+}
+
+XdgMimeAppsPrivate::~XdgMimeAppsPrivate()
+{
+}
+
+XdgMimeApps::XdgMimeApps(QObject *parent)
+    : QObject(*new XdgMimeAppsPrivate, parent)
+{
+    d_func()->init();
+}
+
+XdgMimeApps::~XdgMimeApps()
+{
+}
+
+bool XdgMimeApps::addSupport(const QString &mimeType, const XdgDesktopFile &app)
+{
+    Q_D(XdgMimeApps);
+    if (mimeType.isEmpty() || !app.isValid())
+        return false;
+
+    QMutexLocker locker(&d->mutex);
+    return d->mBackend->addAssociation(mimeType, app);
+}
+
+QList<XdgDesktopFile *> XdgMimeApps::allApps()
+{
+    Q_D(XdgMimeApps);
+    QMutexLocker locker(&d->mutex);
+    return d->mBackend->allApps();
+}
+
+QList<XdgDesktopFile *> XdgMimeApps::apps(const QString &mimeType)
+{
+    Q_D(XdgMimeApps);
+    if (mimeType.isEmpty())
+        return QList<XdgDesktopFile *>();
+
+    QMutexLocker locker(&d->mutex);
+    return d->mBackend->apps(mimeType);
+}
+
+QList<XdgDesktopFile *> XdgMimeApps::categoryApps(const QString &category)
+{
+    if (category.isEmpty())
+        return QList<XdgDesktopFile *>();
+
+    const QString cat = category.toUpper();
+    const QList <XdgDesktopFile *> apps = allApps();
+    QList <XdgDesktopFile *> dl;
+    for (XdgDesktopFile * const df : apps) {
+        const QStringList categories = df->value(QL1S("Categories")).toString().toUpper().split(QL1C(';'));
+        if (!categories.isEmpty() && (categories.contains(cat) || categories.contains(QL1S("X-") + cat)))
+            dl.append(df);
+    }
+    return dl;
+}
+
+QList<XdgDesktopFile *> XdgMimeApps::fallbackApps(const QString &mimeType)
+{
+    Q_D(XdgMimeApps);
+    if (mimeType.isEmpty())
+        return QList<XdgDesktopFile *>();
+
+    QMutexLocker locker(&d->mutex);
+    return d->mBackend->fallbackApps(mimeType);
+}
+
+QList<XdgDesktopFile *> XdgMimeApps::recommendedApps(const QString &mimeType)
+{
+    Q_D(XdgMimeApps);
+    if (mimeType.isEmpty())
+        return QList<XdgDesktopFile *>();
+
+    QMutexLocker locker(&d->mutex);
+    return d->mBackend->recommendedApps(mimeType);
+}
+
+XdgDesktopFile *XdgMimeApps::defaultApp(const QString &mimeType)
+{
+    Q_D(XdgMimeApps);
+    if (mimeType.isEmpty())
+        return nullptr;
+
+    QMutexLocker locker(&d->mutex);
+    return d->mBackend->defaultApp(mimeType);
+}
+
+bool XdgMimeApps::removeSupport(const QString &mimeType, const XdgDesktopFile &app)
+{
+    Q_D(XdgMimeApps);
+    if (mimeType.isEmpty() || !app.isValid())
+        return false;
+
+    QMutexLocker locker(&d->mutex);
+    return d->mBackend->removeAssociation(mimeType, app);
+}
+
+bool XdgMimeApps::reset(const QString &mimeType)
+{
+    Q_D(XdgMimeApps);
+    if (mimeType.isEmpty())
+        return false;
+
+    QMutexLocker locker(&d->mutex);
+    return d->mBackend->reset(mimeType);
+}
+
+bool XdgMimeApps::setDefaultApp(const QString &mimeType, const XdgDesktopFile &app)
+{
+    Q_D(XdgMimeApps);
+    if (mimeType.isEmpty() || !app.isValid())
+        return false;
+
+    if (XdgDesktopFile::id(app.fileName()).isEmpty())
+        return false;
+
+    QMutexLocker locker(&d->mutex);
+    return d->mBackend->setDefaultApp(mimeType, app);
+}
+
+#include "moc_xdgmimeapps.cpp"

--- a/src/qtxdg/xdgmimeapps.h
+++ b/src/qtxdg/xdgmimeapps.h
@@ -1,0 +1,128 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#ifndef XDGMIMEAPPS_H
+#define XDGMIMEAPPS_H
+
+#include <QObject>
+
+#include "xdgmacros.h"
+
+class XdgDesktopFile;
+class XdgMimeAppsPrivate;
+
+class QString;
+
+/*!
+ * \brief The XdgMimeApps class
+ */
+class QTXDG_API XdgMimeApps : public QObject {
+    Q_OBJECT
+    Q_DISABLE_COPY(XdgMimeApps)
+    Q_DECLARE_PRIVATE(XdgMimeApps)
+
+public:
+    /*!
+     * \brief XdgMimeApps constructor
+     */
+    explicit XdgMimeApps(QObject *parent = nullptr);
+
+    /*!
+      * \brief XdgMimeApps destructor
+      */
+    ~XdgMimeApps() override;
+
+    /*!
+     * \brief addSupport
+     * \param mimeType
+     * \param app
+     * \return
+     */
+    bool addSupport(const QString &mimeType, const XdgDesktopFile &app);
+
+    /*!
+     * \brief allApps
+     * \return
+     */
+    QList<XdgDesktopFile *> allApps();
+
+    /*!
+     * \brief apps
+     * \param mimeType
+     * \return
+     */
+    QList<XdgDesktopFile *> apps(const QString &mimeType);
+
+    /*!
+     * \brief categoryApps
+     * \param category
+     * \return
+     */
+    QList<XdgDesktopFile *> categoryApps(const QString &category);
+
+    /*!
+     * \brief fallbackApps
+     * \param mimeType
+     * \return
+     */
+    QList<XdgDesktopFile *> fallbackApps(const QString &mimeType);
+
+    /*!
+     * \brief recommendedApps
+     * \param mimeType
+     * \return
+     */
+    QList<XdgDesktopFile *> recommendedApps(const QString &mimeType);
+
+    /*!
+     * \brief defaultApp
+     * \param mimeType
+     * \return
+     */
+    XdgDesktopFile *defaultApp(const QString &mimeType);
+
+    /*!
+     * \brief removeSupport
+     * \param mimeType
+     * \param app
+     * \return
+     */
+    bool removeSupport(const QString &mimeType, const XdgDesktopFile &app);
+
+    /*!
+     * \brief reset
+     * \param mimeType
+     * \return
+     */
+    bool reset(const QString &mimeType);
+
+    /*!
+     * \brief setDefaultApp
+     * \param mimeType
+     * \param app
+     * \return
+     */
+    bool setDefaultApp(const QString &mimeType, const XdgDesktopFile &app);
+
+Q_SIGNALS:
+    void changed();
+};
+
+#endif // XDGMIMEAPPS_H

--- a/src/qtxdg/xdgmimeapps_p.h
+++ b/src/qtxdg/xdgmimeapps_p.h
@@ -1,0 +1,44 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#ifndef XDGMIMEAPPS_P_H
+#define XDGMIMEAPPS_P_H
+
+#include <private/qobject_p.h>
+#include <QMutex>
+
+class XdgMimeApps;
+class XdgMimeAppsBackendInterface;
+
+class Q_DECL_HIDDEN XdgMimeAppsPrivate : public QObjectPrivate {
+    Q_DECLARE_PUBLIC(XdgMimeApps)
+
+public:
+    XdgMimeAppsPrivate();
+    ~XdgMimeAppsPrivate();
+
+    void init();
+    static XdgMimeAppsPrivate *instance();
+
+    QMutex mutex;
+    XdgMimeAppsBackendInterface *mBackend;
+};
+
+#endif // XDGMIMEAPPS_P_H

--- a/src/qtxdg/xdgmimeappsbackendinterface.cpp
+++ b/src/qtxdg/xdgmimeappsbackendinterface.cpp
@@ -1,0 +1,30 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#include "xdgmimeappsbackendinterface.h"
+
+XdgMimeAppsBackendInterface::XdgMimeAppsBackendInterface(QObject *parent)
+    : QObject(parent)
+{
+}
+
+XdgMimeAppsBackendInterface::~XdgMimeAppsBackendInterface()
+{
+}

--- a/src/qtxdg/xdgmimeappsbackendinterface.h
+++ b/src/qtxdg/xdgmimeappsbackendinterface.h
@@ -1,0 +1,51 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#ifndef XDGMIMEAPPSBACKENDINTERFACE_H
+#define XDGMIMEAPPSBACKENDINTERFACE_H
+
+#include <QObject>
+
+class XdgDesktopFile;
+
+class QString;
+
+class XdgMimeAppsBackendInterface : public QObject {
+    Q_OBJECT
+
+public:
+    explicit XdgMimeAppsBackendInterface(QObject *parent);
+    virtual ~XdgMimeAppsBackendInterface();
+
+    virtual bool addAssociation(const QString &mimeType, const XdgDesktopFile &app) = 0;
+    virtual QList<XdgDesktopFile *> allApps() = 0;
+    virtual QList<XdgDesktopFile *> apps(const QString &mimeType) = 0;
+    virtual XdgDesktopFile *defaultApp(const QString &mimeType) = 0;
+    virtual QList<XdgDesktopFile *> fallbackApps(const QString &mimeType) = 0;
+    virtual QList<XdgDesktopFile *> recommendedApps(const QString &mimeType) = 0;
+    virtual bool reset(const QString &mimeType) = 0;
+    virtual bool removeAssociation(const QString &mimeType, const XdgDesktopFile &app) = 0;
+    virtual bool setDefaultApp(const QString &mimeType, const XdgDesktopFile &app) = 0;
+
+Q_SIGNALS:
+    void changed();
+};
+
+#endif // XDGMIMEAPPSBACKENDINTERFACE_H

--- a/src/qtxdg/xdgmimeappsglibbackend.cpp
+++ b/src/qtxdg/xdgmimeappsglibbackend.cpp
@@ -1,0 +1,232 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#include "xdgmimeappsglibbackend.h"
+#include "xdgmimeapps.h"
+
+#include "qtxdglogging.h"
+#include "xdgdesktopfile.h"
+
+#include <gio/gio.h>
+#include <gio/gdesktopappinfo.h>
+
+#include <QDebug>
+#include <QLoggingCategory>
+#include <QMimeDatabase>
+
+static QList<XdgDesktopFile *> GAppInfoGListToXdgDesktopQList(GList *list)
+{
+    QList<XdgDesktopFile *> dl;
+    for (GList *l = list; l != nullptr; l = l->next) {
+        if (l->data) {
+            const QString file = QString::fromUtf8(g_desktop_app_info_get_filename(G_DESKTOP_APP_INFO(l->data)));
+            if (!file.isEmpty()) {
+                XdgDesktopFile *df = new XdgDesktopFile;
+                if (df->load(file) && df->isValid()) {
+                    dl.append(df);
+                }
+            }
+        }
+    }
+    return dl;
+}
+
+static GDesktopAppInfo *XdgDesktopFileToGDesktopAppinfo(const XdgDesktopFile &app)
+{
+    GDesktopAppInfo *gApp = g_desktop_app_info_new_from_filename(app.fileName().toUtf8().constData());
+    if (gApp == nullptr) {
+        qCWarning(QtXdgMimeAppsGLib, "Failed to load GDesktopAppInfo for '%s'",
+                qPrintable(app.fileName()));
+        return nullptr;
+    }
+    return gApp;
+}
+
+XdgMimeAppsGLibBackend::XdgMimeAppsGLibBackend(QObject *parent)
+    : XdgMimeAppsBackendInterface(parent),
+      mWatcher(nullptr)
+{
+    // Make sure that we have glib support enabled.
+    qunsetenv("QT_NO_GLIB");
+
+    // This is a trick to init the database. Without it, the changed signal
+    // functionality doesn't work properly. Also make sure optimizaters can't
+    // make it go away.
+    volatile GAppInfo *fooApp = g_app_info_get_default_for_type("foo", FALSE);
+    if (fooApp)
+        g_object_unref(G_APP_INFO(fooApp));
+
+    mWatcher = g_app_info_monitor_get();
+    if (mWatcher != nullptr) {
+        g_signal_connect (mWatcher, "changed", G_CALLBACK (_changed), this);
+    }
+}
+
+XdgMimeAppsGLibBackend::~XdgMimeAppsGLibBackend()
+{
+    g_object_unref(mWatcher);
+}
+
+void XdgMimeAppsGLibBackend::_changed(GAppInfoMonitor *monitor, XdgMimeAppsGLibBackend *_this)
+{
+    Q_UNUSED(monitor);
+    Q_EMIT _this->changed();
+}
+
+bool XdgMimeAppsGLibBackend::addAssociation(const QString &mimeType, const XdgDesktopFile &app)
+{
+    GDesktopAppInfo *gApp = XdgDesktopFileToGDesktopAppinfo(app);
+    if (gApp == nullptr)
+        return false;
+
+    GError *error = nullptr;
+    if (g_app_info_add_supports_type(G_APP_INFO(gApp),
+                                           mimeType.toUtf8().constData(), &error) == FALSE) {
+        qCWarning(QtXdgMimeAppsGLib, "Failed to associate '%s' with '%s'. %s",
+                  qPrintable(mimeType), g_desktop_app_info_get_filename(gApp), error->message);
+
+        g_error_free(error);
+        g_object_unref(gApp);
+        return false;
+    }
+    return true;
+}
+
+QList<XdgDesktopFile *> XdgMimeAppsGLibBackend::allApps()
+{
+    GList *list = g_app_info_get_all();
+    QList<XdgDesktopFile *> dl = GAppInfoGListToXdgDesktopQList(list);
+    g_list_free_full(list, g_object_unref);
+    return dl;
+}
+
+QList<XdgDesktopFile *> XdgMimeAppsGLibBackend::apps(const QString &mimeType)
+{
+    QList<XdgDesktopFile *> dl = recommendedApps(mimeType);
+    dl.append(fallbackApps(mimeType));
+    return dl;
+}
+
+QList<XdgDesktopFile *> XdgMimeAppsGLibBackend::fallbackApps(const QString &mimeType)
+{
+    // g_app_info_get_fallback_for_type() doesn't returns the ones in the
+    // recommended list
+    GList *list = g_app_info_get_fallback_for_type(mimeType.toUtf8().constData());
+    QList<XdgDesktopFile *> dl = GAppInfoGListToXdgDesktopQList(list);
+    g_list_free_full(list, g_object_unref);
+    return dl;
+}
+
+QList<XdgDesktopFile *> XdgMimeAppsGLibBackend::recommendedApps(const QString &mimeType)
+{
+    QByteArray ba = mimeType.toUtf8();
+    const char *contentType = ba.constData();
+
+    GAppInfo *defaultApp = g_app_info_get_default_for_type(contentType, FALSE);
+    GList *list = g_app_info_get_recommended_for_type(contentType);
+
+    if (list != nullptr && defaultApp != nullptr) {
+        GAppInfo *first = G_APP_INFO(g_list_nth_data(list, 0));
+        GAppInfo *second = G_APP_INFO(g_list_nth_data(list, 1));
+        if (!g_app_info_equal(defaultApp, first) && g_app_info_equal(defaultApp, second)) {
+            // we are sure that the first element comes from
+            // g_app_info_set_as_last_used(). We remove it becouse it's not
+            // part on the standard
+            list = g_list_remove(list, first);
+        }
+    }
+    QList<XdgDesktopFile *> dl = GAppInfoGListToXdgDesktopQList(list);
+    g_list_free_full(list, g_object_unref);
+    return dl;
+}
+
+bool XdgMimeAppsGLibBackend::removeAssociation(const QString &mimeType, const XdgDesktopFile &app)
+{
+    GDesktopAppInfo *gApp = XdgDesktopFileToGDesktopAppinfo(app);
+    if (gApp == nullptr)
+        return false;
+
+    GError *error = nullptr;
+    if (g_app_info_remove_supports_type(G_APP_INFO(gApp),
+                                           mimeType.toUtf8().constData(), &error) == FALSE) {
+        qCWarning(QtXdgMimeAppsGLib, "Failed to remove association between '%s' and '%s'. %s",
+                  qPrintable(mimeType), g_desktop_app_info_get_filename(gApp), error->message);
+
+        g_error_free(error);
+        g_object_unref(gApp);
+        return false;
+    }
+    return true;
+}
+
+bool XdgMimeAppsGLibBackend::reset(const QString &mimeType)
+{
+    g_app_info_reset_type_associations(mimeType.toUtf8().constData());
+    return true;
+}
+
+XdgDesktopFile *XdgMimeAppsGLibBackend::defaultApp(const QString &mimeType)
+{
+    GAppInfo *appinfo = g_app_info_get_default_for_type(mimeType.toUtf8().constData(), false);
+    if (appinfo == nullptr || !G_IS_DESKTOP_APP_INFO(appinfo)) {
+        return nullptr;
+    }
+
+    const char *file = g_desktop_app_info_get_filename(G_DESKTOP_APP_INFO(appinfo));
+
+    if (file == nullptr) {
+        g_object_unref(appinfo);
+        return nullptr;
+    }
+
+    const QString s = QString::fromUtf8(file);
+    g_object_unref(appinfo);
+
+    XdgDesktopFile *f = new XdgDesktopFile;
+    if (f->load(s) && f->isValid())
+        return f;
+
+    delete f;
+    return nullptr;
+}
+
+bool XdgMimeAppsGLibBackend::setDefaultApp(const QString &mimeType, const XdgDesktopFile &app)
+{
+    GDesktopAppInfo *gApp = XdgDesktopFileToGDesktopAppinfo(app);
+    if (gApp == nullptr)
+        return false;
+
+    GError *error = nullptr;
+    if (g_app_info_set_as_default_for_type(G_APP_INFO(gApp),
+                                           mimeType.toUtf8().constData(), &error) == FALSE) {
+        qCWarning(QtXdgMimeAppsGLib, "Failed to set '%s' as the default for '%s'. %s",
+                  g_desktop_app_info_get_filename(gApp), qPrintable(mimeType), error->message);
+
+        g_error_free(error);
+        g_object_unref(gApp);
+        return false;
+    }
+
+    qCDebug(QtXdgMimeAppsGLib, "Set '%s' as the default for '%s'",
+            g_desktop_app_info_get_filename(gApp), qPrintable(mimeType));
+
+    g_object_unref(gApp);
+    return true;
+}

--- a/src/qtxdg/xdgmimeappsglibbackend.h
+++ b/src/qtxdg/xdgmimeappsglibbackend.h
@@ -1,0 +1,52 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#ifndef XDGMIMEAPPSGLIBBACKEND_H
+#define XDGMIMEAPPSGLIBBACKEND_H
+
+#include "xdgmimeappsbackendinterface.h"
+
+class XdgDesktopFile;
+
+class QString;
+
+typedef struct _GAppInfoMonitor GAppInfoMonitor;
+
+class Q_DECL_HIDDEN XdgMimeAppsGLibBackend : public XdgMimeAppsBackendInterface {
+public:
+    XdgMimeAppsGLibBackend(QObject *parent);
+    ~XdgMimeAppsGLibBackend() override;
+
+    bool addAssociation(const QString &mimeType, const XdgDesktopFile &app) override;
+    QList<XdgDesktopFile *> allApps() override;
+    QList<XdgDesktopFile *> apps(const QString &mimeType) override;
+    XdgDesktopFile *defaultApp(const QString &mimeType) override;
+    QList<XdgDesktopFile *> fallbackApps(const QString &mimeType) override;
+    QList<XdgDesktopFile *> recommendedApps(const QString &mimeType) override;
+    bool removeAssociation(const QString &mimeType, const XdgDesktopFile &app) override;
+    bool reset(const QString &mimeType) override;
+    bool setDefaultApp(const QString &mimeType, const XdgDesktopFile &app) override;
+
+private:
+    GAppInfoMonitor *mWatcher;
+    static void _changed(GAppInfoMonitor *monitor, XdgMimeAppsGLibBackend *_this);
+};
+
+#endif // XDGMIMEAPPSGLIBBACKEND_H

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(mat)

--- a/src/tools/mat/CMakeLists.txt
+++ b/src/tools/mat/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(qtxdg-mat
     matcommandmanager.cpp
     matcommandinterface.cpp
     defappmatcommand.cpp
+    openmatcommand.cpp
 
     qtxdg-mat.cpp
 )

--- a/src/tools/mat/CMakeLists.txt
+++ b/src/tools/mat/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_executable(qtxdg-mat
+    matcommandmanager.cpp
+    matcommandinterface.cpp
+    defappmatcommand.cpp
+
+    qtxdg-mat.cpp
+)
+
+target_compile_definitions(qtxdg-mat
+    PRIVATE
+        "-DQTXDG_VERSION=\"${QTXDG_VERSION_STRING}\""
+        "QT_NO_KEYWORDS"
+)
+
+target_link_libraries(qtxdg-mat
+    ${QTXDGX_LIBRARY_NAME}
+)
+
+install(TARGETS
+    qtxdg-mat
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    COMPONENT Runtime
+)

--- a/src/tools/mat/CMakeLists.txt
+++ b/src/tools/mat/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(qtxdg-mat
     matcommandinterface.cpp
     defappmatcommand.cpp
     openmatcommand.cpp
+    mimetypematcommand.cpp
 
     qtxdg-mat.cpp
 )

--- a/src/tools/mat/defappmatcommand.cpp
+++ b/src/tools/mat/defappmatcommand.cpp
@@ -1,0 +1,173 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#include "defappmatcommand.h"
+#include "matglobals.h"
+
+#include "xdgdesktopfile.h"
+#include "xdgmacros.h"
+#include "xdgmimeapps.h"
+
+#include <QCommandLineOption>
+#include <QCommandLineParser>
+#include <QCoreApplication>
+#include <QDebug>
+
+#include <iostream>
+
+enum DefAppCommandMode {
+    CommandModeGetDefApp,
+    CommandModeSetDefApp
+};
+
+struct DefAppData {
+    DefAppData() : mode(CommandModeGetDefApp) {}
+
+    DefAppCommandMode mode;
+    QString defAppName;
+    QStringList mimeTypes;
+};
+
+static CommandLineParseResult parseCommandLine(QCommandLineParser *parser, DefAppData *data, QString *errorMessage)
+{
+    parser->clearPositionalArguments();
+    parser->setApplicationDescription(QL1S("Get/Set the default application for a mimetype"));
+
+    parser->addPositionalArgument(QL1S("defapp"), QSL("mimetype(s)"),
+                                  QCoreApplication::tr("[mimetype(s)...]"));
+
+    const QCommandLineOption defAppNameOption(QStringList() << QSL("s") << QSL("set"),
+                QSL("Application to be set as default"), QSL("app name"));
+
+    parser->addOption(defAppNameOption);
+    const QCommandLineOption helpOption = parser->addHelpOption();
+    const QCommandLineOption versionOption = parser->addVersionOption();
+
+    if (!parser->parse(QCoreApplication::arguments())) {
+        *errorMessage = parser->errorText();
+        return CommandLineError;
+    }
+
+    if (parser->isSet(versionOption)) {
+        return CommandLineVersionRequested;
+    }
+
+    if (parser->isSet(helpOption)) {
+        return CommandLineHelpRequested;
+    }
+
+    const bool isDefAppNameSet = parser->isSet(defAppNameOption);
+    QString defAppName;
+
+    if (isDefAppNameSet)
+        defAppName = parser->value(defAppNameOption);
+
+    if (isDefAppNameSet && defAppName.isEmpty()) {
+        *errorMessage = QSL("No application name");
+        return CommandLineError;
+    }
+
+    QStringList mimeTypes = parser->positionalArguments();
+
+    if (mimeTypes.size() < 2) {
+        *errorMessage = QSL("MimeType missing");
+        return CommandLineError;
+    }
+
+    mimeTypes.removeAt(0);
+
+    if (!isDefAppNameSet && mimeTypes.size() > 1) {
+        *errorMessage = QSL("Only one mimeType, please");
+        return CommandLineError;
+    }
+
+    data->mode = isDefAppNameSet ? CommandModeSetDefApp : CommandModeGetDefApp;
+    data->defAppName = defAppName;
+    data->mimeTypes = mimeTypes;
+
+    return CommandLineOk;
+}
+
+DefAppMatCommand::DefAppMatCommand(QCommandLineParser *parser)
+    : MatCommandInterface(QL1S("defapp"),
+                          QL1S("Get/Set the default application for a mimetype"),
+                          parser)
+{
+   Q_CHECK_PTR(parser);
+}
+
+DefAppMatCommand::~DefAppMatCommand()
+{
+}
+
+int DefAppMatCommand::run(const QStringList & /*arguments*/)
+{
+    bool success = true;
+    DefAppData data;
+    QString errorMessage;
+    if (!MatCommandInterface::parser()) {
+        qFatal("DefAppMatCommand::run: MatCommandInterface::parser() returned a null pointer");
+    }
+
+    switch(parseCommandLine(parser(), &data, &errorMessage)) {
+    case CommandLineOk:
+        break;
+    case CommandLineError:
+        std::cerr << qPrintable(errorMessage);
+        std::cerr << "\n\n";
+        std::cerr << qPrintable(parser()->helpText());
+        return EXIT_FAILURE;
+    case CommandLineVersionRequested:
+        showVersion();
+        Q_UNREACHABLE();
+    case CommandLineHelpRequested:
+        showHelp();
+        Q_UNREACHABLE();
+    }
+
+    if (data.mode == CommandModeGetDefApp) { // Get default App
+        XdgMimeApps apps;
+        const QString mimeType = data.mimeTypes.constFirst();
+        XdgDesktopFile *defApp = apps.defaultApp(mimeType);
+        if (defApp != nullptr) {
+            std::cout << qPrintable(XdgDesktopFile::id(defApp->fileName())) << "\n";
+            delete defApp;
+        } else {
+//            std::cout << qPrintable(QSL("No default application for '%1'\n").arg(mimeType));
+        }
+    } else { // Set default App
+        XdgDesktopFile app;
+        if (!app.load(data.defAppName)) {
+            std::cerr << qPrintable(QSL("Could not find find '%1'\n").arg(data.defAppName));
+            return EXIT_FAILURE;
+        }
+
+        XdgMimeApps apps;
+        for (const QString &mimeType : qAsConst(data.mimeTypes)) {
+            if (!apps.setDefaultApp(mimeType, app)) {
+                std::cerr << qPrintable(QSL("Could not set '%1' as default for '%2'\n").arg(app.fileName(), mimeType));
+                success = false;
+            } else {
+                std::cout << qPrintable(QSL("Set '%1' as default for '%2'\n").arg(app.fileName(), mimeType));
+            }
+        }
+    }
+    return success ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/tools/mat/defappmatcommand.h
+++ b/src/tools/mat/defappmatcommand.h
@@ -1,0 +1,34 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#ifndef DEFAPPCOMMAND_H
+#define DEFAPPCOMMAND_H
+
+#include "matcommandinterface.h"
+
+class DefAppMatCommand : public MatCommandInterface {
+public:
+    explicit DefAppMatCommand(QCommandLineParser *parser);
+    ~DefAppMatCommand() override;
+
+    int run(const QStringList &) override;
+};
+
+#endif // DEFAPPCOMMAND_H

--- a/src/tools/mat/matcommandinterface.cpp
+++ b/src/tools/mat/matcommandinterface.cpp
@@ -1,0 +1,53 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#include "matcommandinterface.h"
+
+#include "xdgmacros.h"
+
+#include <QCommandLineParser>
+
+MatCommandInterface::MatCommandInterface(const QString &name, const QString &description, QCommandLineParser *parser)
+    : mName(name),
+      mDescription(description),
+      mParser(parser)
+{
+    Q_CHECK_PTR(parser);
+}
+
+MatCommandInterface::~MatCommandInterface()
+{
+}
+
+void MatCommandInterface::showHelp(int exitCode) const
+{
+    if (!mParser)
+        return;
+
+    mParser->showHelp(exitCode);
+}
+
+void MatCommandInterface::showVersion() const
+{
+    if (!mParser)
+        return;
+
+    mParser->showVersion();
+}

--- a/src/tools/mat/matcommandinterface.h
+++ b/src/tools/mat/matcommandinterface.h
@@ -1,0 +1,88 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#ifndef MATCOMMANDINTERFACE_H
+#define MATCOMMANDINTERFACE_H
+
+#include <QStringList>
+
+class QCommandLineParser;
+/*!
+ * \brief The MatCommandInterface class
+ */
+class MatCommandInterface {
+
+public:
+    /*!
+     * \brief MatCommandInterface
+     * \param name
+     * \param description
+     * \param parser
+     */
+    explicit MatCommandInterface(const QString &name, const QString &description, QCommandLineParser *parser);
+
+    /*!
+     * \brief ~MatCommandInterface
+     */
+    virtual ~MatCommandInterface();
+
+    /*!
+     * \brief name
+     * \return
+     */
+    inline QString name() const { return mName; }
+
+    /*!
+     * \brief description
+     * \return
+     */
+    inline QString description() const { return mDescription; }
+
+    /*!
+     * \brief parser
+     * \return
+     */
+    inline QCommandLineParser *parser() const { return mParser; }
+
+    /*!
+     * \brief run
+     * \param arguments
+     * \return
+     */
+    virtual int run(const QStringList &arguments) = 0;
+
+    /*!
+     * \brief showHelp
+     * \param exitCode
+     */
+    virtual void showHelp(int exitCode = 0) const;
+
+    /*!
+     * \brief showVersion
+     */
+    virtual void showVersion() const;
+
+private:
+    QString mName;
+    QString mDescription;
+    QCommandLineParser *mParser;
+};
+
+#endif // MATCOMMANDINTERFACE_H

--- a/src/tools/mat/matcommandmanager.cpp
+++ b/src/tools/mat/matcommandmanager.cpp
@@ -1,0 +1,67 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#include "matcommandmanager.h"
+
+#include "xdgmacros.h"
+
+#include "matcommandinterface.h"
+
+#include <QDebug>
+
+
+MatCommandManager::MatCommandManager()
+{
+}
+
+MatCommandManager::~MatCommandManager()
+{
+    qDeleteAll(mCommands);
+    mCommands.clear();
+}
+
+void MatCommandManager::add(MatCommandInterface *cmd)
+{
+    mCommands.append(cmd);
+}
+
+QList<MatCommandInterface *> MatCommandManager::commands() const
+{
+    return mCommands;
+}
+
+QString MatCommandManager::descriptionsHelpText() const
+{
+    QString text;
+    int longestName = 0;
+    const QLatin1String doubleSpace("  ");
+
+    for (const auto *cmd : qAsConst(mCommands)) {
+        longestName = qMax(longestName, cmd->name().size());
+    }
+    longestName += 2; // account for the inital dobule space
+    for (const auto *cmd : qAsConst(mCommands)) {
+        QString ptext = doubleSpace + cmd->name();
+        ptext = ptext.leftJustified(longestName, QL1C(' '));
+        ptext += doubleSpace + cmd->description() + QL1C('\n');
+        text.append(ptext);
+    }
+    return text;
+}

--- a/src/tools/mat/matcommandmanager.h
+++ b/src/tools/mat/matcommandmanager.h
@@ -1,0 +1,66 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#ifndef MATCOMMANDMANAGER_H
+#define MATCOMMANDMANAGER_H
+
+#include <QList>
+
+class MatCommandInterface;
+
+/*!
+ * \brief The MatCommandManager class
+ */
+class MatCommandManager {
+
+public:
+    /*!
+     * \brief MatCommandManager
+     */
+    MatCommandManager();
+
+    /*!
+     * \brief ~MatCommandManager
+     */
+    virtual ~MatCommandManager();
+
+    /*!
+     * \brief add
+     * \param cmd
+     */
+    void add(MatCommandInterface *cmd);
+
+    /*!
+     * \brief commands
+     * \return
+     */
+    QList<MatCommandInterface *> commands() const;
+
+    /*!
+     * \brief descriptionsHelpText
+     * \return
+     */
+    QString descriptionsHelpText() const;
+
+private:
+    QList <MatCommandInterface *> mCommands;
+};
+
+#endif // MATCOMMANDMANAGER_H

--- a/src/tools/mat/matglobals.h
+++ b/src/tools/mat/matglobals.h
@@ -1,0 +1,31 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#ifndef MATGLOBALS_H
+#define MATGLOBALS_H
+
+enum CommandLineParseResult {
+    CommandLineOk,
+    CommandLineError,
+    CommandLineVersionRequested,
+    CommandLineHelpRequested
+};
+
+#endif // MATGLOBALS_H

--- a/src/tools/mat/mimetypematcommand.cpp
+++ b/src/tools/mat/mimetypematcommand.cpp
@@ -1,0 +1,130 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2019  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+#include "mimetypematcommand.h"
+#include "matglobals.h"
+
+#include "xdgmacros.h"
+#include "xdgdesktopfile.h"
+#include "xdgmimeapps.h"
+
+#include <QCommandLineOption>
+#include <QCommandLineParser>
+#include <QCoreApplication>
+#include <QDebug>
+#include <QFileInfo>
+#include <QMimeDatabase>
+#include <QMimeType>
+#include <QStringList>
+#include <QtGlobal>
+#include <QUrl>
+
+#include <iostream>
+
+MimeTypeMatCommand::MimeTypeMatCommand(QCommandLineParser *parser)
+    : MatCommandInterface(QL1S("mimetype"),
+                          QL1S("Determines a file (mime)type"),
+                          parser)
+{
+}
+
+MimeTypeMatCommand::~MimeTypeMatCommand()
+{
+}
+
+static CommandLineParseResult parseCommandLine(QCommandLineParser *parser, QString *file, QString *errorMessage)
+{
+    parser->clearPositionalArguments();
+    parser->setApplicationDescription(QL1S("Determines a file (mime)type"));
+
+    parser->addPositionalArgument(QL1S("mimetype"), QSL("file | URL"),
+                                  QCoreApplication::tr("[file | URL]"));
+
+    parser->addHelpOption();
+    parser->addVersionOption();
+
+    parser->process(QCoreApplication::arguments());
+    QStringList fs = parser->positionalArguments();
+    if (fs.size() < 2) {
+        *errorMessage = QSL("No file given");
+        return CommandLineError;
+    }
+
+    fs.removeAt(0);
+
+    if (fs.size() > 1) {
+        *errorMessage = QSL("Only one file, please");
+        return CommandLineError;
+    }
+    *file = fs.at(0);
+
+    return CommandLineOk;
+}
+
+int MimeTypeMatCommand::run(const QStringList &arguments)
+{
+    Q_UNUSED(arguments);
+
+    QString errorMessage;
+    QString file;
+
+    switch(parseCommandLine(parser(), &file, &errorMessage)) {
+    case CommandLineOk:
+        break;
+    case CommandLineError:
+        std::cerr << qPrintable(errorMessage);
+        std::cerr << "\n\n";
+        std::cerr << qPrintable(parser()->helpText());
+        return EXIT_FAILURE;
+    case CommandLineVersionRequested:
+        parser()->showVersion();
+        Q_UNREACHABLE();
+    case CommandLineHelpRequested:
+        parser()->showHelp();
+        Q_UNREACHABLE();
+    }
+
+    bool isLocalFile = false;
+    QString localFilename;
+    const QUrl url(file);
+    const QString scheme = url.scheme();
+    if (scheme.isEmpty()) {
+        isLocalFile = true;
+        localFilename = file;
+    } else if (scheme == QL1S("file")) {
+        isLocalFile = true;
+        localFilename = QUrl(file).toLocalFile();
+    }
+
+    if (isLocalFile) {
+        const QFileInfo info(file);
+        if (!info.exists(localFilename)) {
+            std::cerr << qPrintable(QSL("Cannot access '%1': No such file or directory\n").arg(file));
+            return EXIT_FAILURE;
+        } else {
+            QMimeDatabase mimeDb;
+            const QMimeType mimeType = mimeDb.mimeTypeForFile(info, QMimeDatabase::MatchExtension);
+            std::cout << qPrintable(mimeType.name()) << "\n";
+            return EXIT_SUCCESS;
+        }
+    } else { // not a local file
+        std::cerr << qPrintable(QSL("Can't handle '%1': '%2' scheme not supported\n").arg(file, scheme));
+        return EXIT_FAILURE;
+    }
+}

--- a/src/tools/mat/mimetypematcommand.h
+++ b/src/tools/mat/mimetypematcommand.h
@@ -1,0 +1,34 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2019  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#ifndef MIMETYPEMATCOMMAND_H
+#define MIMETYPEMATCOMMAND_H
+
+#include "matcommandinterface.h"
+
+class MimeTypeMatCommand : public MatCommandInterface {
+public:
+    explicit MimeTypeMatCommand(QCommandLineParser *parser);
+    ~MimeTypeMatCommand() override;
+
+    int run(const QStringList &arguments) override;
+};
+
+#endif // MIMETYPEMATCOMMAND_H

--- a/src/tools/mat/openmatcommand.cpp
+++ b/src/tools/mat/openmatcommand.cpp
@@ -1,0 +1,142 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#include "openmatcommand.h"
+#include "matglobals.h"
+
+#include "xdgmacros.h"
+#include "xdgdesktopfile.h"
+#include "xdgmimeapps.h"
+
+#include <QCommandLineOption>
+#include <QCommandLineParser>
+#include <QCoreApplication>
+#include <QDebug>
+#include <QFileInfo>
+#include <QMimeDatabase>
+#include <QMimeType>
+#include <QStringList>
+#include <QtGlobal>
+#include <QUrl>
+
+#include <iostream>
+
+OpenMatCommand::OpenMatCommand(QCommandLineParser *parser)
+    : MatCommandInterface(QL1S("open"),
+                          QSL("Open files with the default application"),
+                          parser)
+{
+}
+
+OpenMatCommand::~OpenMatCommand()
+{
+}
+
+static CommandLineParseResult parseCommandLine(QCommandLineParser *parser, QStringList *files, QString *errorMessage)
+{
+    parser->clearPositionalArguments();
+    parser->setApplicationDescription(QL1S("Open files with the default application"));
+
+    parser->addPositionalArgument(QL1S("open"), QSL("files | URLs"),
+                                  QCoreApplication::tr("[files | URLs]"));
+
+    parser->addHelpOption();
+    parser->addVersionOption();
+
+    parser->process(QCoreApplication::arguments());
+    QStringList fs = parser->positionalArguments();
+    if (fs.size() < 2) {
+        *errorMessage = QSL("No file or URL given");
+        return CommandLineError;
+    }
+
+    fs.removeAt(0);
+
+    *files = fs;
+
+    return CommandLineOk;
+}
+
+int OpenMatCommand::run(const QStringList &arguments)
+{
+    Q_UNUSED(arguments);
+
+    bool success = true;
+    QString errorMessage;
+    QStringList files;
+
+    switch(parseCommandLine(parser(), &files, &errorMessage)) {
+    case CommandLineOk:
+        break;
+    case CommandLineError:
+        std::cerr << qPrintable(errorMessage);
+        std::cerr << "\n\n";
+        std::cerr << qPrintable(parser()->helpText());
+        return EXIT_FAILURE;
+    case CommandLineVersionRequested:
+        parser()->showVersion();
+        Q_UNREACHABLE();
+    case CommandLineHelpRequested:
+        parser()->showHelp();
+        Q_UNREACHABLE();
+    }
+
+    XdgMimeApps appsDb;
+    QMimeDatabase mimeDb;
+    XdgDesktopFile *df;
+    bool isLocalFile = false;
+    QString localFilename;
+    for (const QString &urlString : qAsConst(files)) {
+        const QUrl url(urlString);
+        const QString scheme = url.scheme();
+        if (scheme.isEmpty()) {
+            isLocalFile = true;
+            localFilename = urlString;
+        } else if (scheme == QL1S("file")) {
+            isLocalFile = true;
+            localFilename = QUrl(urlString).toLocalFile();
+        }
+
+        if (isLocalFile) {
+            const QFileInfo f (localFilename);
+            if (!f.exists()) {
+                std::cerr << qPrintable(QSL("Cannot access %1: No such file or directory\n").arg(urlString));
+                break;
+            } else {
+                const QMimeType mimeType = mimeDb.mimeTypeForFile(f);
+                df = appsDb.defaultApp(mimeType.name());
+            }
+        } else { // not a local file
+			const QString contentType = QString::fromLatin1("x-scheme-handler/%1").arg(scheme);
+			df = appsDb.defaultApp(contentType);
+        }
+
+        if (df) { // default app found
+            if (!df->startDetached(urlString)) {
+                std::cerr << qPrintable(
+                        QSL("Error while running the default application (%1) for %2\n").arg(df->name(), urlString));
+                success = false;
+            }
+        } else { // no default app found
+            std::cout << qPrintable(QSL("No default application for '%1'\n").arg(urlString));
+        }
+    }
+    return success ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/tools/mat/openmatcommand.h
+++ b/src/tools/mat/openmatcommand.h
@@ -1,0 +1,34 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#ifndef OPENMATCOMMAND_H
+#define OPENMATCOMMAND_H
+
+#include "matcommandinterface.h"
+
+class OpenMatCommand : public MatCommandInterface {
+public:
+    explicit OpenMatCommand(QCommandLineParser *parser);
+    ~OpenMatCommand() override;
+
+    int run(const QStringList &arguments) override;
+};
+
+#endif // OPENMATCOMMAND_H

--- a/src/tools/mat/qtxdg-mat.cpp
+++ b/src/tools/mat/qtxdg-mat.cpp
@@ -1,0 +1,104 @@
+/*
+ * libqtxdg - An Qt implementation of freedesktop.org xdg specs
+ * Copyright (C) 2018  Luís Pereira <luis.artur.pereira@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#include "matcommandmanager.h"
+#include "defappmatcommand.h"
+
+#include "xdgmacros.h"
+
+#include <QCoreApplication>
+#include <QCommandLineOption>
+#include <QCommandLineParser>
+#include <QDebug>
+
+extern void Q_CORE_EXPORT qt_call_post_routines();
+
+[[noreturn]] void showHelp(const QString &parserHelp, const QString &commandsDescription, int exitCode = 0);
+
+[[noreturn]] void showHelp(const QString &parserHelp, const QString &commandsDescription, int exitCode)
+{
+    QString text;
+    const QLatin1Char nl('\n');
+
+    text.append(parserHelp);
+    text.append(nl);
+    text.append(QCoreApplication::tr("Available commands:\n"));
+    text.append(commandsDescription);
+    text.append(nl);
+    fputs(qPrintable(text), stdout);
+
+    qt_call_post_routines();
+    ::exit(exitCode);
+}
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+    int runResult = 0;
+    app.setApplicationName(QSL("qtxdg-mat"));
+    app.setApplicationVersion(QSL(QTXDG_VERSION));
+    app.setOrganizationName(QSL("LXQt"));
+    app.setOrganizationDomain(QSL("lxqt.org"));
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription(QSL("QtXdg MimeApps Tool"));
+
+    parser.addPositionalArgument(QSL("command"),
+                                 QSL("Command to execute."));
+
+    QScopedPointer<MatCommandManager> manager(new MatCommandManager());
+
+    MatCommandInterface *const mimeCmd = new DefAppMatCommand(&parser);
+    manager->add(mimeCmd);
+
+    // Find out the positional arguments.
+    parser.parse(QCoreApplication::arguments());
+    const QStringList args = parser.positionalArguments();
+    const QString command = args.isEmpty() ? QString() : args.first();
+    bool cmdFound = false;
+
+    const QList <MatCommandInterface *> commands = manager->commands();
+    for (auto *const cmd : commands) {
+        if (command == cmd->name()) {
+            cmdFound = true;
+            runResult = cmd->run(args);
+        }
+        if (cmdFound)
+            break;
+    }
+
+    if (!cmdFound) {
+        const QCommandLineOption helpOption = parser.addHelpOption();
+        const QCommandLineOption versionOption = parser.addVersionOption();
+        parser.parse(QCoreApplication::arguments());
+        if (parser.isSet(helpOption)) {
+            showHelp(parser.helpText(), manager->descriptionsHelpText(), EXIT_SUCCESS);
+            Q_UNREACHABLE();
+        }
+        if (parser.isSet(versionOption)) {
+            parser.showVersion();
+            Q_UNREACHABLE();
+        }
+        showHelp(parser.helpText(), manager->descriptionsHelpText(), EXIT_FAILURE);
+        Q_UNREACHABLE();
+    } else {
+        return runResult;
+    }
+}

--- a/src/tools/mat/qtxdg-mat.cpp
+++ b/src/tools/mat/qtxdg-mat.cpp
@@ -20,6 +20,7 @@
 
 #include "matcommandmanager.h"
 #include "defappmatcommand.h"
+#include "openmatcommand.h"
 
 #include "xdgmacros.h"
 
@@ -67,6 +68,9 @@ int main(int argc, char *argv[])
 
     MatCommandInterface *const mimeCmd = new DefAppMatCommand(&parser);
     manager->add(mimeCmd);
+
+    MatCommandInterface *const openCmd = new OpenMatCommand(&parser);
+    manager->add(openCmd);
 
     // Find out the positional arguments.
     parser.parse(QCoreApplication::arguments());

--- a/src/tools/mat/qtxdg-mat.cpp
+++ b/src/tools/mat/qtxdg-mat.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "matcommandmanager.h"
+#include "mimetypematcommand.h"
 #include "defappmatcommand.h"
 #include "openmatcommand.h"
 
@@ -71,6 +72,9 @@ int main(int argc, char *argv[])
 
     MatCommandInterface *const openCmd = new OpenMatCommand(&parser);
     manager->add(openCmd);
+
+    MatCommandInterface *const mimeTypeCmd = new MimeTypeMatCommand(&parser);
+    manager->add(mimeTypeCmd);
 
     // Find out the positional arguments.
     parser.parse(QCoreApplication::arguments());

--- a/test/qtxdg_test.cpp
+++ b/test/qtxdg_test.cpp
@@ -33,6 +33,7 @@
 #include "xdgdesktopfile.h"
 #include "xdgdesktopfile_p.h"
 #include "xdgdirs.h"
+#include "xdgmimeapps.h"
 
 #include <QtTest>
 
@@ -138,7 +139,8 @@ void QtXdgTest::testCustomFormat()
 
 QString QtXdgTest::xdgDesktopFileDefaultApp(QString mimetype)
 {
-    XdgDesktopFile *defaultApp = XdgDesktopFileCache::getDefaultApp(mimetype);
+    XdgMimeApps appsDb;
+    XdgDesktopFile *defaultApp = appsDb.defaultApp(mimetype);
     QString defaultAppS;
     if (defaultApp)
     {


### PR DESCRIPTION
When fully implemented it will render XdgDesktopFileCache obsolete.
Currently GLib implementation is used as backend. The design allows
other backends to be used, if desired.

Note to packagers: GLib is now a explicit dependency.