### PR TITLE
Cover all KDE colors schemes for symbolic icons

### DIFF
--- a/src/xdgiconloader/xdgiconloader.cpp
+++ b/src/xdgiconloader/xdgiconloader.cpp
@@ -841,8 +841,8 @@ QPixmap ScalableFollowsColorEntry::pixmap(const QSize &size, QIcon::Mode mode, Q
             const QPalette pal = qApp->palette();
             // Note: indexes are assembled as in qtsvg (QSvgIconEnginePrivate::hashKey())
             QMap<int, QString> style_sheets;
-            style_sheets[(QIcon::Normal<<4)|QIcon::Off] = QStringLiteral(".ColorScheme-Text{color:%1;}").arg(pal.windowText().color().name());
-            style_sheets[(QIcon::Selected<<4)|QIcon::Off] = QStringLiteral(".ColorScheme-Text{color:%1;}").arg(pal.highlightedText().color().name());
+            style_sheets[(QIcon::Normal<<4)|QIcon::Off] = QStringLiteral(".ColorScheme-Text,.ColorScheme-PositiveText,.ColorScheme-NeutralText,.ColorScheme-NegativeText{color:%1;}").arg(pal.windowText().color().name());
+            style_sheets[(QIcon::Selected<<4)|QIcon::Off] = QStringLiteral(".ColorScheme-Text,.ColorScheme-PositiveText,.ColorScheme-NeutralText,.ColorScheme-NegativeText{color:%1;}").arg(pal.highlightedText().color().name());
             QMap<int, QSharedPointer<QXmlStreamWriter> > writers;
             for (auto i = style_sheets.cbegin(); i != style_sheets.cend(); ++i)
             {


### PR DESCRIPTION
In our support for KDE symbolic icons, we only considered `.ColorScheme-Text`. But some Breeze symbolic icons use KDE-specific schemes like `.ColorScheme-NegativeText`. Of course, we don't use such colors but even `.ColorScheme-Text` is something we've taken from KDE (it could be any string otherwise). So, it's better to cover all KDE text colors but set all of them to the same color.

Without this patch, some Breeze icons with KDE-specific schemes (like the 16-px `window-close.svg` or `application-exit.svg`) would always be pitch black -- even with dark Qt styles -- because their schemes are erased. But with this patch, they are like other icons: light on dark backgrounds and dark on light ones.

In short, this is needed if we want KDE icon sets to be really usable under LXQt too.