### PR TITLE
Consider device pixel ratio when painting

### DIFF
--- a/src/xdgiconloader/xdgiconloader.cpp
+++ b/src/xdgiconloader/xdgiconloader.cpp
@@ -631,7 +631,8 @@ void XdgIconLoaderEngine::paint(QPainter *painter, const QRect &rect,
 #if defined(Q_DEAD_CODE_FROM_QT4_MAC)
     pixmapSize *= qt_mac_get_scalefactor();
 #endif
-    painter->drawPixmap(rect, pixmap(pixmapSize, mode, state));
+    const qreal dpr = painter->device()->devicePixelRatioF();
+    painter->drawPixmap(rect, pixmap(pixmapSize * dpr, mode, state));
 }
 
 /*


### PR DESCRIPTION
Otherwise, (view item) icons will be blurry with PNG icon sets and scale factors greater than 1. `KIconEngine::paint()` does the same thing.

Also see https://github.com/lxqt/pcmanfm-qt/issues/834#issuecomment-444715167

IMHO, it's better not to merge this before the 0.14 release because it might need more tests.