### PR TITLE
xdgdesktopfile: Avoid freeze for DBusActivatable apps

### DIFF
--- a/src/qtxdg/CMakeLists.txt
+++ b/src/qtxdg/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
 set(QTX_LIBRARIES Qt5::Widgets Qt5::Xml Qt5::DBus)
 
 set(libqtxdg_PUBLIC_H_FILES
@@ -50,10 +52,18 @@ set(libqtxdg_CPP_FILES
     xdgmimetype.cpp
 )
 
+QT5_ADD_DBUS_INTERFACE(DBUS_INTERFACE_SRCS
+    dbus/org.freedesktop.Application.xml
+    application_interface
+)
+
+set_property(SOURCE ${DBUS_INTERFACE_SRCS} PROPERTY SKIP_AUTOGEN ON)
+
 add_library(${QTXDGX_LIBRARY_NAME} SHARED
     ${libqtxdg_PUBLIC_H_FILES}
     ${libqtxdg_PRIVATE_H_FILES}
     ${libqtxdg_CPP_FILES}
+    ${DBUS_INTERFACE_SRCS}
 )
 
 target_link_libraries(${QTXDGX_LIBRARY_NAME}

--- a/src/qtxdg/dbus/org.freedesktop.Application.xml
+++ b/src/qtxdg/dbus/org.freedesktop.Application.xml
@@ -1,0 +1,25 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<!--
+    Based on https://specifications.freedesktop.org/desktop-entry-spec/1.1/ar01s07.html
+-->
+<node>
+    <interface name='org.freedesktop.Application'>
+        <method name='Activate'>
+            <arg type='a{sv}' name='platform_data' direction='in'/>
+            <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
+        </method>
+        <method name='Open'>
+            <arg type='as' name='uris' direction='in'/>
+            <arg type='a{sv}' name='platform_data' direction='in'/>
+            <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
+        </method>
+        <method name='ActivateAction'>
+            <arg type='s' name='action_name' direction='in'/>
+            <arg type='av' name='parameter' direction='in'/>
+            <arg type='a{sv}' name='platform_data' direction='in'/>
+            <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="QVariantMap"/>
+        </method>
+    </interface>
+</node>
+


### PR DESCRIPTION
For case when the DBusActivatable application is unresponsive the
startDetached() can block for a long time (the Qt default 25s DBus
timeout). Blocking can't be avoided while using QDBusInterface, because
the object can block directly in its contructor.

So we use the generated interface class and set the timeout for the DBus
call to 1500ms (can be overriden env variable QTXDG_DBUSACTIVATE_TIMEOUT).

See also: https://bugreports.qt.io/browse/QTBUG-75016

fixes #181 