### PR TITLE
Prevent a c++11 range-loop possible detach

### DIFF
--- a/src/qtxdg/xdgmenureader.cpp
+++ b/src/qtxdg/xdgmenureader.cpp
@@ -236,7 +236,7 @@ void XdgMenuReader::processMergeFileTag(QDomElement& element, QStringList* merge
         if (relativeName.isEmpty())
             return;
 
-        for (const QString &configDir : configDirs)
+        for (const QString &configDir : qAsConst(configDirs))
         {
             if (QFileInfo::exists(configDir + relativeName))
             {


### PR DESCRIPTION
Missed this one. Don't know how.