### PR TITLE
Use std::swap()

### DIFF
--- a/src/qtxdg/xdgmimetype.cpp
+++ b/src/qtxdg/xdgmimetype.cpp
@@ -22,6 +22,7 @@
 
 #include "xdgicon.h"
 
+#include <algorithm>
 
 class XdgMimeTypePrivate : public QSharedData {
 public:
@@ -79,6 +80,11 @@ XdgMimeType &XdgMimeType::operator=(const XdgMimeType &other)
     return *this;
 }
 
+void XdgMimeType::swap(XdgMimeType &other) noexcept
+{
+    QMimeType::swap(other);
+    std::swap(dx, other.dx);
+}
 
 XdgMimeType::~XdgMimeType()
 {

--- a/src/qtxdg/xdgmimetype.h
+++ b/src/qtxdg/xdgmimetype.h
@@ -80,12 +80,7 @@ public:
         return !QMimeType::operator==(other);
     }
 
-    void swap(XdgMimeType &other)
-    {
-        QMimeType::swap(other);
-        // Not using std::swap here as that does not work with Qt 5.14
-        dx.swap(other.dx);
-    }
+    void swap(XdgMimeType &other) noexcept;
 
     //! Destructs the mimetype
     ~XdgMimeType();


### PR DESCRIPTION
Commit 6f597b30cef2bdefc9ca5362cdf195294ebb9556 replaced qSwap() with
std::swap(). It caused a FTBFS with Qt5.14
Commit c6b89c7af127d49739c9d2d9d323c931c509dcaa fixed it.
But it can be made to work with std::swap(), which is more readable, and
resilient to changes in Qt internals.
Tested with Qt5.14.2 and Qt5.14.1