### PR TITLE
Silent known clazy warnings

### DIFF
--- a/src/qtxdg/xdgdesktopfile.cpp
+++ b/src/qtxdg/xdgdesktopfile.cpp
@@ -25,6 +25,8 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
+// clazy:excludeall=non-pod-global-static
+
 #include "desktopenvironment_p.cpp"
 #include "xdgdesktopfile.h"
 #include "xdgdesktopfile_p.h"

--- a/src/qtxdg/xdgdirs.cpp
+++ b/src/qtxdg/xdgdirs.cpp
@@ -25,6 +25,8 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
+// clazy:excludeall=non-pod-global-static
+
 #include "xdgdirs.h"
 #include <cstdlib>
 #include <QDir>

--- a/src/xdgiconloader/xdgiconloader.cpp
+++ b/src/xdgiconloader/xdgiconloader.cpp
@@ -30,6 +30,9 @@
 ** $QT_END_LICENSE$
 **
 ****************************************************************************/
+
+// clazy:excludeall=non-pod-global-static
+
 #ifndef QT_NO_ICON
 #include "xdgiconloader_p.h"
 


### PR DESCRIPTION
Silent warnings about non-POD global statics. They are known.
Multi-line declarations confuses clazy parser so we apply it to the whole
file.