### PR TITLE
xdgiconloader: Calling actualSize() before pixmap() would return 0x0.

### DIFF
--- a/src/xdgiconloader/xdgiconloader.cpp
+++ b/src/xdgiconloader/xdgiconloader.cpp
@@ -767,6 +767,9 @@ QSize XdgIconLoaderEngine::actualSize(const QSize &size, QIcon::Mode mode,
             PixmapEntry * pix_e;
             if (0 == dir_size && nullptr != (pix_e = dynamic_cast<PixmapEntry *>(entry)))
             {
+                // Ensure that basePixmap is lazily initialized
+                if (pix_e->basePixmap.isNull())
+                    pix_e->basePixmap.load(pix_e->filename);
                 QSize pix_size = pix_e->basePixmap.size();
                 dir_size = qMin(pix_size.width(), pix_size.height());
             }


### PR DESCRIPTION
The base pixmap is lazily loaded. If actualSize() is called before pixmap(), it needs to load the pixmap to get the correct size.

This fixes missing icons in the action view on lxqt-panel first load.

"Before" screenshot (note missing icon for Asunder):

![image](https://user-images.githubusercontent.com/1244737/80069848-09496f80-8510-11ea-93d0-c6d496a7e405.png)
