### PR TITLE
Move member initialization to the initialize list

### DIFF
--- a/src/qtxdg/xdgmenuapplinkprocessor.cpp
+++ b/src/qtxdg/xdgmenuapplinkprocessor.cpp
@@ -33,13 +33,12 @@
 #include <QDir>
 
 
-XdgMenuApplinkProcessor::XdgMenuApplinkProcessor(QDomElement& element,  XdgMenu* menu, XdgMenuApplinkProcessor *parent) :
-    QObject(parent)
+XdgMenuApplinkProcessor::XdgMenuApplinkProcessor(QDomElement& element,  XdgMenu* menu, XdgMenuApplinkProcessor *parent)
+    : QObject(parent),
+      mParent(parent),
+      mElement(element),
+      mMenu(menu)
 {
-    mElement = element;
-    mParent = parent;
-    mMenu = menu;
-
     mOnlyUnallocated = element.attribute(QLatin1String("onlyUnallocated")) == QLatin1String("1");
 
     MutableDomElementIterator i(element, QLatin1String("Menu"));

--- a/src/qtxdg/xdgmenuapplinkprocessor.h
+++ b/src/qtxdg/xdgmenuapplinkprocessor.h
@@ -82,11 +82,11 @@ class XdgMenuAppFileInfo: public QObject
     Q_OBJECT
 public:
     explicit XdgMenuAppFileInfo(XdgDesktopFile* desktopFile, const QString& id,  QObject *parent)
-        : QObject(parent)
+        : QObject(parent),
+          mDesktopFile(desktopFile),
+          mAllocated(false),
+          mId(id)
     {
-        mDesktopFile = desktopFile;
-        mAllocated = false;
-        mId = id;
     }
 
     XdgDesktopFile* desktopFile() const { return mDesktopFile; }

--- a/src/qtxdg/xdgmenulayoutprocessor.cpp
+++ b/src/qtxdg/xdgmenulayoutprocessor.cpp
@@ -60,15 +60,14 @@ QDomElement findLastElementByTag(const QDomElement element, const QString tagNam
  </DefaultLayout>
  ************************************************/
 XdgMenuLayoutProcessor::XdgMenuLayoutProcessor(QDomElement& element):
-    mElement(element)
+    mElement(element),
+    mDefaultLayout(findLastElementByTag(element, QLatin1String("DefaultLayout")))
 {
     mDefaultParams.mShowEmpty = false;
     mDefaultParams.mInline = false;
     mDefaultParams.mInlineLimit = 4;
     mDefaultParams.mInlineHeader = true;
     mDefaultParams.mInlineAlias = false;
-
-    mDefaultLayout = findLastElementByTag(element, QLatin1String("DefaultLayout"));
 
     if (mDefaultLayout.isNull())
     {
@@ -98,10 +97,9 @@ XdgMenuLayoutProcessor::XdgMenuLayoutProcessor(QDomElement& element):
 
 
 XdgMenuLayoutProcessor::XdgMenuLayoutProcessor(QDomElement& element, XdgMenuLayoutProcessor *parent):
+	mDefaultParams(parent->mDefaultParams),
     mElement(element)
 {
-    mDefaultParams = parent->mDefaultParams;
-
     // DefaultLayout ............................
     QDomElement defaultLayout = findLastElementByTag(element, QLatin1String("DefaultLayout"));
 

--- a/src/qtxdg/xdgmenurules.cpp
+++ b/src/qtxdg/xdgmenurules.cpp
@@ -143,10 +143,10 @@ bool XdgMenuRuleNot::check(const QString& desktopFileId, const XdgDesktopFile& d
  if the desktop entry has the given desktop-file id. See Desktop-File Id.
  ************************************************/
 XdgMenuRuleFileName::XdgMenuRuleFileName(const QDomElement& element, QObject *parent) :
-    XdgMenuRule(element, parent)
+    XdgMenuRule(element, parent),
+    mId(element.text())
 {
     //qDebug() << "Create FILENAME rule";
-    mId = element.text();
 }
 
 
@@ -163,9 +163,9 @@ bool XdgMenuRuleFileName::check(const QString& desktopFileId, const XdgDesktopFi
  if the desktop entry has the given category in its Categories field.
  ************************************************/
 XdgMenuRuleCategory::XdgMenuRuleCategory(const QDomElement& element, QObject *parent) :
-    XdgMenuRule(element, parent)
+    XdgMenuRule(element, parent),
+    mCategory(element.text())
 {
-    mCategory = element.text();
 }
 
 

--- a/src/qtxdg/xmlhelper.h
+++ b/src/qtxdg/xmlhelper.h
@@ -37,9 +37,9 @@ class QTXDG_API DomElementIterator
 {
 public:
     explicit DomElementIterator(const QDomNode& parentNode, const QString& tagName = QString())
+        : mTagName(tagName),
+          mParent(parentNode)
     {
-        mTagName = tagName;
-        mParent = parentNode;
         toFront();
     }
 
@@ -96,9 +96,9 @@ class MutableDomElementIterator
 {
 public:
     explicit MutableDomElementIterator(QDomNode& parentNode, const QString& tagName = QString())
+        : mTagName(tagName),
+          mParent(parentNode)
     {
-        mTagName = tagName;
-        mParent = parentNode;
         toFront();
     }
 


### PR DESCRIPTION
When an object of a class is created, the constructors of all member
variables are called consecutively in the order the variables are declared,
even if we don't explicitly write them to the initialization list.