### PR TITLE
Workaround for the bug of Qt 5.15 in `QMouseEvent::buttons()` with `QMenu`

### DIFF
--- a/src/qtxdg/xdgmenuwidget.cpp
+++ b/src/qtxdg/xdgmenuwidget.cpp
@@ -158,7 +158,13 @@ bool XdgMenuWidget::event(QEvent* event)
 
 void XdgMenuWidgetPrivate::mouseMoveEvent(QMouseEvent *event)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(5,15,0))
+    // NOTE: Because of a bug in Qt 5.15.0, "event->buttons()"
+    // always returns "Qt::NoButton" with "QEvent::MouseMove".
+    if (!(QGuiApplication::mouseButtons() & Qt::LeftButton))
+#else
     if (!(event->buttons() & Qt::LeftButton))
+#endif
         return;
 
     if ((event->pos() - mDragStartPosition).manhattanLength() < QApplication::startDragDistance())


### PR DESCRIPTION
Closes https://github.com/lxqt/lxqt/issues/1821

Although this workaround works fine, I'm not sure if we should merge it. @luis-pereira, shouldn't we wait for a fix in Qt instead (even if it doesn't come soon)?