### PR TITLE
Avoid invalid memory access in QIconCacheGtkReader::lookup()

### DIFF
--- a/src/xdgiconloader/xdgiconloader.cpp
+++ b/src/xdgiconloader/xdgiconloader.cpp
@@ -220,7 +220,7 @@ static quint32 icon_name_hash(const char *p)
 QVector<const char *> QIconCacheGtkReader::lookup(const QStringRef &name)
 {
     QVector<const char *> ret;
-    if (!isValid())
+    if (!isValid() || name.isEmpty())
         return ret;
 
     QByteArray nameUtf8 = name.toUtf8();


### PR DESCRIPTION
Backport of commit:
https://code.qt.io/cgit/qt/qtbase.git/commit/src/gui/image/qiconloader.cpp?id=98c5f22161e25c0f6867c0bf7db7aa8d6fcf6074