### PR TITLE
Improve readability in container emptiness check

### DIFF
--- a/src/qtxdg/xdgmenurules.cpp
+++ b/src/qtxdg/xdgmenurules.cpp
@@ -112,8 +112,7 @@ bool XdgMenuRuleAnd::check(const QString& desktopFileId, const XdgDesktopFile& d
     for (std::list<XdgMenuRule*>::const_iterator i=mChilds.cbegin(); i!=mChilds.cend(); ++i)
         if (!(*i)->check(desktopFileId, desktopFile))  return false;
 
-    //FIXME: Doon't use implicit casts
-    return mChilds.size();
+    return !mChilds.empty();
 }
 
 

--- a/src/tools/mat/defemailclientmatcommand.cpp
+++ b/src/tools/mat/defemailclientmatcommand.cpp
@@ -88,13 +88,13 @@ static CommandLineParseResult parseCommandLine(QCommandLineParser *parser, DefEm
     QStringList posArgs = parser->positionalArguments();
     posArgs.removeAt(0);
 
-    if (isDefEmailClientNameSet && posArgs.size() > 0) {
+    if (isDefEmailClientNameSet && !posArgs.empty()) {
         *errorMessage = QSL("Extra arguments given: ");
         errorMessage->append(posArgs.join(QLatin1Char(',')));
         return CommandLineError;
     }
 
-    if (isListAvailableSet && (isDefEmailClientNameSet || posArgs.size() > 0)) {
+    if (isListAvailableSet && (isDefEmailClientNameSet || !posArgs.empty())) {
         *errorMessage = QSL("list-available can't be used with other options and doesn't take arguments");
         return CommandLineError;
     }

--- a/src/tools/mat/deffilemanagermatcommand.cpp
+++ b/src/tools/mat/deffilemanagermatcommand.cpp
@@ -88,13 +88,13 @@ static CommandLineParseResult parseCommandLine(QCommandLineParser *parser, DefFi
     QStringList posArgs = parser->positionalArguments();
     posArgs.removeAt(0);
 
-    if (isDefFileManagerNameSet && posArgs.size() > 0) {
+    if (isDefFileManagerNameSet && !posArgs.empty()) {
         *errorMessage = QSL("Extra arguments given: ");
         errorMessage->append(posArgs.join(QLatin1Char(',')));
         return CommandLineError;
     }
 
-    if (isListAvailableSet && (isDefFileManagerNameSet || posArgs.size() > 0)) {
+    if (isListAvailableSet && (isDefFileManagerNameSet || !posArgs.empty())) {
         *errorMessage = QSL("list-available can't be used with other options and doesn't take arguments");
         return CommandLineError;
     }

--- a/src/tools/mat/defwebbrowsermatcommand.cpp
+++ b/src/tools/mat/defwebbrowsermatcommand.cpp
@@ -88,18 +88,18 @@ static CommandLineParseResult parseCommandLine(QCommandLineParser *parser, DefWe
     QStringList posArgs = parser->positionalArguments();
     posArgs.removeAt(0);
 
-    if (isDefWebBrowserNameSet && posArgs.size() > 0) {
+    if (isDefWebBrowserNameSet && !posArgs.empty()) {
         *errorMessage = QSL("Extra arguments given: ");
         errorMessage->append(posArgs.join(QLatin1Char(',')));
         return CommandLineError;
     }
 
-    if (!isDefWebBrowserNameSet && posArgs.size() > 0) {
+    if (!isDefWebBrowserNameSet && !posArgs.empty()) {
         *errorMessage = QSL("To set the default browser use the -s/--set option");
         return CommandLineError;
     }
 
-    if (isListAvailableSet && (isDefWebBrowserNameSet || posArgs.size() > 0)) {
+    if (isListAvailableSet && (isDefWebBrowserNameSet || !posArgs.empty())) {
         *errorMessage = QSL("list-available can't be used with other options and doesn't take arguments");
         return CommandLineError;
     }

--- a/src/xdgiconloader/xdgiconloader.cpp
+++ b/src/xdgiconloader/xdgiconloader.cpp
@@ -613,7 +613,7 @@ void XdgIconLoaderEngine::ensureLoaded()
         m_info.entries.clear();
         m_info.iconName.clear();
 
-        Q_ASSERT(m_info.entries.size() == 0);
+        Q_ASSERT(m_info.entries.empty());
         m_info = XdgIconLoader::instance()->loadIcon(m_iconName);
         m_key = QIconLoader::instance()->themeKey();
     }


### PR DESCRIPTION
Use empty() instead of size() is easier to understand.
Also avoids an implicit cast.