### PR TITLE
Move to Qt5 signal/slot syntax

### DIFF
--- a/src/qtxdg/xdgaction.cpp
+++ b/src/qtxdg/xdgaction.cpp
@@ -92,7 +92,7 @@ void XdgAction::load(const XdgDesktopFile& desktopFile)
         setText(mDesktopFile.name().replace(QLatin1Char('&'), QLatin1String("&&")));
         setToolTip(mDesktopFile.comment());
 
-        connect(this, SIGNAL(triggered()), this, SLOT(runConmmand()));
+        connect(this, &XdgAction::triggered, this, &XdgAction::runConmmand);
         QMetaObject::invokeMethod(this, "updateIcon", Qt::QueuedConnection);
     }
     else

--- a/src/qtxdg/xdgmenu.cpp
+++ b/src/qtxdg/xdgmenu.cpp
@@ -75,12 +75,12 @@ XdgMenuPrivate::XdgMenuPrivate(XdgMenu *parent):
     mRebuildDelayTimer.setSingleShot(true);
     mRebuildDelayTimer.setInterval(REBUILD_DELAY);
 
-    connect(&mRebuildDelayTimer, SIGNAL(timeout()), this, SLOT(rebuild()));
-    connect(&mWatcher, SIGNAL(fileChanged(QString)), &mRebuildDelayTimer, SLOT(start()));
-    connect(&mWatcher, SIGNAL(directoryChanged(QString)), &mRebuildDelayTimer, SLOT(start()));
+    connect(&mRebuildDelayTimer, &QTimer::timeout, this, &XdgMenuPrivate::rebuild);
+    connect(&mWatcher, &QFileSystemWatcher::fileChanged, &mRebuildDelayTimer, QOverload<>::of(&QTimer::start));
+    connect(&mWatcher, &QFileSystemWatcher::directoryChanged, &mRebuildDelayTimer, QOverload<>::of(&QTimer::start));
 
 
-    connect(this, SIGNAL(changed()), q_ptr, SIGNAL(changed()));
+    connect(this, &XdgMenuPrivate::changed, q_ptr, &XdgMenu::changed);
 }
 
 

--- a/src/qtxdg/xdgmenu_p.h
+++ b/src/qtxdg/xdgmenu_p.h
@@ -37,7 +37,7 @@ class QStringList;
 class QString;
 class QDomDocument;
 
-class XdgMenuPrivate: QObject
+class XdgMenuPrivate : public QObject
 {
 Q_OBJECT
 public:


### PR DESCRIPTION
Just one notable change. I had to set the public inheritance of XdgMenuPrivate from QObject. It doesn't work otherwise. Anyway I coudn't find one reason why it has to privately inherit.