### PR TITLE
Use QSvgRenderer for SVG icons

### DIFF
--- a/src/xdgiconloader/xdgiconloader.cpp
+++ b/src/xdgiconloader/xdgiconloader.cpp
@@ -860,8 +860,6 @@ QPixmap ScalableFollowsColorEntry::pixmap(const QSize &size, QIcon::Mode mode, Q
         }
         hCol = pal.highlight().color().name();
     }
-    QString styleSheet = STYLE.arg(txtCol, bgCol, hCol);
-
     QString key = QLatin1String("lxqt_")
                   % filename
                   % HexString<int>(mode)
@@ -879,6 +877,7 @@ QPixmap ScalableFollowsColorEntry::pixmap(const QSize &size, QIcon::Mode mode, Q
         QFile device{filename};
         if (device.open(QIODevice::ReadOnly))
         {
+            QString styleSheet = STYLE.arg(txtCol, bgCol, hCol);
             QByteArray svgBuffer;
             QXmlStreamWriter writer(&svgBuffer);
             QXmlStreamReader xmlReader(&device);

--- a/src/xdgiconloader/xdgiconloader.cpp
+++ b/src/xdgiconloader/xdgiconloader.cpp
@@ -864,10 +864,9 @@ QPixmap ScalableFollowsColorEntry::pixmap(const QSize &size, QIcon::Mode mode, Q
                   % filename
                   % HexString<int>(mode)
                   % HexString<int>(state)
-                  % txtCol % bgCol % hCol
                   % HexString<int>(size.width())
-                  % HexString<int>(size.height());
-
+                  % HexString<int>(size.height())
+                  % txtCol % bgCol % hCol;
     if (!QPixmapCache::find(key, &pm))
     {
         int icnSize = qMin(size.width(), size.height());


### PR DESCRIPTION
`QSvgRenderer` is used with a cache for both ordinary and colorized SVG icons. In this way, LXQt's icon handling cannot be broken by intruding icon engines, which register themselves for "svg" (see https://github.com/lxqt/libqtxdg/issues/246). Moreover, it does not depend on a specific code structure of `qtsvg` or any other icon engine.