### PR TITLE
Added a nullity check for paint device

### DIFF
--- a/src/xdgiconloader/xdgiconloader.cpp
+++ b/src/xdgiconloader/xdgiconloader.cpp
@@ -622,10 +622,11 @@ void XdgIconLoaderEngine::ensureLoaded()
 }
 
 void XdgIconLoaderEngine::paint(QPainter *painter, const QRect &rect,
-                             QIcon::Mode mode, QIcon::State state)
+                                QIcon::Mode mode, QIcon::State state)
 {
     QSize pixmapSize = rect.size();
-    const qreal dpr = painter->device()->devicePixelRatioF();
+    auto paintDevice = painter->device();
+    const qreal dpr = paintDevice ? paintDevice->devicePixelRatioF() : qApp->devicePixelRatio();
     painter->drawPixmap(rect, pixmap(QSizeF(pixmapSize * dpr).toSize(), mode, state));
 }
 


### PR DESCRIPTION
It may not be needed in practice but Qt does it in `qicon.cpp` → `QPixmapIconEngine::paint()`.