### PR TITLE
Fix a QStringView related FTBFS

### DIFF
--- a/src/xdgiconloader/xdgiconloader.cpp
+++ b/src/xdgiconloader/xdgiconloader.cpp
@@ -48,7 +48,9 @@
 #include <QtCore/QList>
 #include <QtCore/QDir>
 #include <QtCore/QSettings>
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
 #include <QtCore/QStringView>
+#endif
 #include <QtGui/QPainter>
 #include <QImageReader>
 #include <QXmlStreamReader>
@@ -109,7 +111,11 @@ class QIconCacheGtkReader
 {
 public:
     explicit QIconCacheGtkReader(const QString &themeDir);
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
     QVector<const char *> lookup(QStringView);
+#else
+    QVector<const char *> lookup(const QStringRef &);
+#endif
     bool isValid() const { return m_isValid; }
     bool reValid(bool infoRefresh);
 private:
@@ -219,7 +225,12 @@ static quint32 icon_name_hash(const char *p)
     with this name is present. The char* are pointers to the mapped data.
     For example, this would return { "32x32/apps", "24x24/apps" , ... }
  */
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
 QVector<const char *> QIconCacheGtkReader::lookup(QStringView name)
+#else
+QVector<const char *> QIconCacheGtkReader::lookup(const QStringRef &name)
+#endif
 {
     QVector<const char *> ret;
     if (!isValid() || name.isEmpty())
@@ -401,7 +412,11 @@ QThemeIconInfo XdgIconLoader::findIconHelper(const QString &themeName,
     const QString xpmext(QLatin1String(".xpm"));
 
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
     QStringView iconNameFallback(iconName);
+#else
+    QStringRef iconNameFallback(&iconName);
+#endif
 
     // Iterate through all icon's fallbacks in current theme
     if (info.entries.isEmpty()) {


### PR DESCRIPTION
QStringView was introduced in Qt 5.10 but some methods were introduced in
later versions. QStringView::lastIndexOf() was introduced in Qt 5.14.
Fixes https://github.com/lxqt/libqtxdg/issues/250.