### PR TITLE
Ignore the cache and do the full look-ups as before

### DIFF
--- a/src/xdgiconloader/xdgiconloader.cpp
+++ b/src/xdgiconloader/xdgiconloader.cpp
@@ -421,15 +421,17 @@ QThemeIconInfo XdgIconLoader::findIconHelper(const QString &themeName,
                 const auto result = cache->lookup(iconNameFallback);
                 if (cache->isValid()) {
                     const QVector<QIconDirInfo> subDirsCopy = subDirs;
-                    subDirs.clear();
-                    subDirs.reserve(result.count());
-                    for (const char *s : result) {
-                        QString path = QString::fromUtf8(s);
-                        auto it = std::find_if(subDirsCopy.cbegin(), subDirsCopy.cend(),
-                                               [&](const QIconDirInfo &info) {
-                                                   return info.path == path; } );
-                        if (it != subDirsCopy.cend()) {
-                            subDirs.append(*it);
+                    if (result.count()) {
+                        subDirs.clear();
+                        subDirs.reserve(result.count());
+                        for (const char *s : result) {
+                            QString path = QString::fromUtf8(s);
+                            auto it = std::find_if(subDirsCopy.cbegin(), subDirsCopy.cend(),
+                                                   [&](const QIconDirInfo &info) {
+                                                       return info.path == path; } );
+                            if (it != subDirsCopy.cend()) {
+                                subDirs.append(*it);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
If the icon is not found in the cache, Do not need to clear the sub
directory, just ignore the cache and do a full lookup as before.