### PR TITLE
XdgMenuWidget: fix for sometimes dragging incorrect action

### DIFF
--- a/src/qtxdg/xdgmenuwidget.cpp
+++ b/src/qtxdg/xdgmenuwidget.cpp
@@ -165,7 +165,7 @@ void XdgMenuWidgetPrivate::mouseMoveEvent(QMouseEvent *event)
         return;
 
     Q_Q(XdgMenuWidget);
-    XdgAction *a = qobject_cast<XdgAction*>(q->actionAt(event->pos()));
+    XdgAction *a = qobject_cast<XdgAction*>(q->actionAt(mDragStartPosition));
     if (!a)
         return;
 


### PR DESCRIPTION
When starting drag, it should get the action that was clicked instead of the action currently under the cursor when qt detects drag action.

Causes issues in `lxqt-panel/plugin-mainmenu` when dragging items to quicklaunch or desktop, causing the adjacent item to be dragged instead.