### PR TITLE
Consider Qt's fallback search paths when finding icons

### DIFF
--- a/src/xdgiconloader/xdgiconloader.cpp
+++ b/src/xdgiconloader/xdgiconloader.cpp
@@ -487,6 +487,31 @@ QThemeIconInfo XdgIconLoader::findIconHelper(const QString &themeName,
         }
     }
 
+    if (info.entries.isEmpty()) {
+        // Also, consider Qt's fallback search paths (which are not defined by Freedesktop)
+        // if the icon is not found in any inherited theme
+        const auto fallbackPaths = QIcon::fallbackSearchPaths();
+        for (const auto &fallbackPath : fallbackPaths) {
+            const QString pngPath = fallbackPath + QLatin1Char('/') + iconName + pngext;
+            if (QFile::exists(pngPath)) {
+                PixmapEntry *iconEntry = new PixmapEntry;
+                QIconDirInfo dirInfo(fallbackPath);
+                iconEntry->dir = dirInfo;
+                iconEntry->filename = pngPath;
+                info.entries.prepend(iconEntry);
+            } else {
+                const QString svgPath = fallbackPath + QLatin1Char('/') + iconName + svgext;
+                if (gSupportsSvg && QFile::exists(svgPath)) {
+                    ScalableEntry *iconEntry = new ScalableEntry;
+                    QIconDirInfo dirInfo(fallbackPath);
+                    iconEntry->dir = dirInfo;
+                    iconEntry->filename = svgPath;
+                    info.entries.append(iconEntry);
+                }
+            }
+        }
+    }
+
     if (dashFallback && info.entries.isEmpty()) {
         // If it's possible - find next fallback for the icon
         const int indexOfDash = iconNameFallback.lastIndexOf(QLatin1Char('-'));


### PR DESCRIPTION
Closes https://github.com/lxqt/libqtxdg/issues/258

Notes:

 * For respecting Freedesktop standards, Qt's fallback search paths are taken into account only after inherited paths.
 * Colorizing of SVG icons is ignored with Qt's fallback paths because it depends on icon themes, not on paths.
 * To test it, you could do something like this in a code:

```c++
    QIcon::setFallbackSearchPaths(QIcon::fallbackSearchPaths() << PARENT_DIR_OF_EXTRA_ICON);
    anAction->setIcon(QIcon::fromTheme(EXTRA_ICON_NAME));
```