### PR TITLE
Consider XDG_DATA_HOME when computing desktop entry id

### DIFF
--- a/src/qtxdg/xdgdesktopfile.cpp
+++ b/src/qtxdg/xdgdesktopfile.cpp
@@ -1230,9 +1230,9 @@ QString XdgDesktopFile::id(const QString &fileName, bool checkFileExists)
     }
 
     QString id = f.absoluteFilePath();
-    const QStringList dataDirs = XdgDirs::dataDirs();
+    const QStringList dirs = QStringList() << XdgDirs::dataHome() << XdgDirs::dataDirs();
 
-    for (const QString &d : dataDirs) {
+    for (const QString &d : dirs) {
         if (id.startsWith(d)) {
             // remove only the first occurence
             id.replace(id.indexOf(d), d.size(), QString());


### PR DESCRIPTION
The standard doesn't refer to XDG_DATA_HOME. It should be considered, allowing
the id of an desktop entry located in XDG_DATA_HOME to be properly computed.
XDG_DATA_HOME is taken into consideration when searching for a desktop entry,
it make no sense not to consider it for computing id.