### PR TITLE
qtxdg-mat: Handle '--help-all' option

### DIFF
--- a/src/tools/mat/defappmatcommand.cpp
+++ b/src/tools/mat/defappmatcommand.cpp
@@ -69,7 +69,7 @@ static CommandLineParseResult parseCommandLine(QCommandLineParser *parser, DefAp
         return CommandLineVersionRequested;
     }
 
-    if (parser->isSet(helpOption)) {
+    if (parser->isSet(helpOption) || parser->isSet(QSL("help-all"))) {
         return CommandLineHelpRequested;
     }
 

--- a/src/tools/mat/defemailclientmatcommand.cpp
+++ b/src/tools/mat/defemailclientmatcommand.cpp
@@ -74,7 +74,7 @@ static CommandLineParseResult parseCommandLine(QCommandLineParser *parser, DefEm
         return CommandLineVersionRequested;
     }
 
-    if (parser->isSet(helpOption)) {
+    if (parser->isSet(helpOption) || parser->isSet(QSL("help-all"))) {
         return CommandLineHelpRequested;
     }
 

--- a/src/tools/mat/deffilemanagermatcommand.cpp
+++ b/src/tools/mat/deffilemanagermatcommand.cpp
@@ -74,7 +74,7 @@ static CommandLineParseResult parseCommandLine(QCommandLineParser *parser, DefFi
         return CommandLineVersionRequested;
     }
 
-    if (parser->isSet(helpOption)) {
+    if (parser->isSet(helpOption) || parser->isSet(QSL("help-all"))) {
         return CommandLineHelpRequested;
     }
 

--- a/src/tools/mat/defterminalmatcommand.cpp
+++ b/src/tools/mat/defterminalmatcommand.cpp
@@ -75,7 +75,7 @@ static CommandLineParseResult parseCommandLine(QCommandLineParser *parser, DefTe
         return CommandLineVersionRequested;
     }
 
-    if (parser->isSet(helpOption)) {
+    if (parser->isSet(helpOption) || parser->isSet(QSL("help-all"))) {
         return CommandLineHelpRequested;
     }
 

--- a/src/tools/mat/defwebbrowsermatcommand.cpp
+++ b/src/tools/mat/defwebbrowsermatcommand.cpp
@@ -74,7 +74,7 @@ static CommandLineParseResult parseCommandLine(QCommandLineParser *parser, DefWe
         return CommandLineVersionRequested;
     }
 
-    if (parser->isSet(helpOption)) {
+    if (parser->isSet(helpOption) || parser->isSet(QSL("help-all"))) {
         return CommandLineHelpRequested;
     }
 

--- a/src/tools/mat/mimetypematcommand.cpp
+++ b/src/tools/mat/mimetypematcommand.cpp
@@ -54,10 +54,22 @@ static CommandLineParseResult parseCommandLine(QCommandLineParser *parser, QStri
     parser->addPositionalArgument(QL1S("mimetype"), QSL("file | URL"),
                                   QCoreApplication::tr("[file | URL]"));
 
-    parser->addHelpOption();
-    parser->addVersionOption();
+    const QCommandLineOption helpOption = parser->addHelpOption();
+    const QCommandLineOption versionOption = parser->addVersionOption();
 
-    parser->process(QCoreApplication::arguments());
+    if (!parser->parse(QCoreApplication::arguments())) {
+        *errorMessage = parser->errorText();
+        return CommandLineError;
+    }
+
+    if (parser->isSet(versionOption)) {
+        return CommandLineVersionRequested;
+    }
+
+    if (parser->isSet(helpOption) || parser->isSet(QSL("help-all"))) {
+        return CommandLineHelpRequested;
+    }
+
     QStringList fs = parser->positionalArguments();
     if (fs.size() < 2) {
         *errorMessage = QSL("No file given");

--- a/src/tools/mat/openmatcommand.cpp
+++ b/src/tools/mat/openmatcommand.cpp
@@ -55,10 +55,22 @@ static CommandLineParseResult parseCommandLine(QCommandLineParser *parser, QStri
     parser->addPositionalArgument(QL1S("open"), QSL("files | URLs"),
                                   QCoreApplication::tr("[files | URLs]"));
 
-    parser->addHelpOption();
-    parser->addVersionOption();
+    const QCommandLineOption helpOption = parser->addHelpOption();
+    const QCommandLineOption versionOption = parser->addVersionOption();
 
-    parser->process(QCoreApplication::arguments());
+    if (!parser->parse(QCoreApplication::arguments())) {
+        *errorMessage = parser->errorText();
+        return CommandLineError;
+    }
+
+    if (parser->isSet(versionOption)) {
+        return CommandLineVersionRequested;
+    }
+
+    if (parser->isSet(helpOption) || parser->isSet(QSL("help-all"))) {
+        return CommandLineHelpRequested;
+    }
+
     QStringList fs = parser->positionalArguments();
     if (fs.size() < 2) {
         *errorMessage = QSL("No file or URL given");

--- a/src/tools/mat/qtxdg-mat.cpp
+++ b/src/tools/mat/qtxdg-mat.cpp
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
         const QCommandLineOption helpOption = parser.addHelpOption();
         const QCommandLineOption versionOption = parser.addVersionOption();
         parser.parse(QCoreApplication::arguments());
-        if (parser.isSet(helpOption)) {
+        if (parser.isSet(helpOption) || parser.isSet(QSL("help-all"))) {
             showHelp(parser.helpText(), manager->descriptionsHelpText(), EXIT_SUCCESS);
             Q_UNREACHABLE();
         }


### PR DESCRIPTION
Wasn't being handled.
Just a documentation error, or a shortcoming in the API.
Upstream Qt bug description: https://bugreports.qt.io/browse/QTBUG-92567