### PR TITLE
Consider single-quoted strings to be literals in Exec keys

### DIFF
--- a/src/qtxdg/xdgdesktopfile.cpp
+++ b/src/qtxdg/xdgdesktopfile.cpp
@@ -1212,7 +1212,17 @@ QStringList XdgDesktopFile::expandExecString(const QStringList& urls) const
         }
 
         // ----------------------------------------------------------
-        result << expandEnvVariables(token);
+        if (token.startsWith(QLatin1Char('\'')) && token.endsWith(QLatin1Char('\'')))
+        {
+            // Consider 'XXX' to be a string literal.
+            // WARNING: This is beyond Desktop Entry Specification but,
+            // apparently, most DEs do it.
+            result << token.chopped(1).remove(0, 1);
+        }
+        else
+        {
+            result << expandEnvVariables(token);
+        }
     }
 
     return result;

--- a/src/qtxdg/xdgdesktopfile.cpp
+++ b/src/qtxdg/xdgdesktopfile.cpp
@@ -1005,7 +1005,9 @@ static QStringList parseCombinedArgString(const QString &program)
     QStringList args;
     QString tmp;
     int quoteCount = 0;
+    int singleQuoteCount = 0;
     bool inQuote = false;
+    bool inSingleQuote = false;
 
     // handle quoting. tokens can be surrounded by double quotes
     // "hello world". three consecutive double quotes represent
@@ -1020,12 +1022,21 @@ static QStringList parseCombinedArgString(const QString &program)
             }
             continue;
         }
+        if (program.at(i) == QLatin1Char('\'')) {
+            ++singleQuoteCount;
+            continue;
+        }
         if (quoteCount) {
             if (quoteCount == 1)
                 inQuote = !inQuote;
             quoteCount = 0;
         }
-        if (!inQuote && program.at(i).isSpace()) {
+        if (singleQuoteCount) {
+            if (singleQuoteCount == 1)
+                inSingleQuote = !inSingleQuote;
+            singleQuoteCount = 0;
+        }
+        if (!inQuote && !inSingleQuote && program.at(i).isSpace()) {
             if (!tmp.isEmpty()) {
                 args += tmp;
                 tmp.clear();


### PR DESCRIPTION
According to Desktop Entry Specification, we should *not* do so but, apparently, most DEs do it.

Closes https://github.com/lxqt/lxqt-panel/issues/1705