### PR TITLE
Supported set use the dash fallback for icon name on XdgIconLoader

### DIFF
--- a/src/xdgiconloader/xdgiconloader.cpp
+++ b/src/xdgiconloader/xdgiconloader.cpp
@@ -569,7 +569,7 @@ QThemeIconInfo XdgIconLoader::loadIcon(const QString &name) const
     const QString theme_name = QIconLoader::instance()->themeName();
     if (!theme_name.isEmpty()) {
         QStringList visited;
-        auto info = findIconHelper(theme_name, name, visited, true);
+        auto info = findIconHelper(theme_name, name, visited, m_dashFallback);
         if (info.entries.isEmpty()) {
             const auto unthemedInfo = unthemedFallback(name, QIcon::themeSearchPaths());
             if (unthemedInfo.entries.isEmpty()) {

--- a/src/xdgiconloader/xdgiconloader_p.h
+++ b/src/xdgiconloader/xdgiconloader_p.h
@@ -140,6 +140,8 @@ public:
      */
     inline bool followColorScheme() const { return m_followColorScheme; }
     void setFollowColorScheme(bool enable);
+    inline bool dashFallback() const { return m_dashFallback; }
+    void setDashFallback(bool fallback) { m_dashFallback = fallback; }
 
     XdgIconTheme theme() { return themeList.value(QIconLoader::instance()->themeName()); }
     static XdgIconLoader *instance();
@@ -152,6 +154,7 @@ private:
     QThemeIconInfo unthemedFallback(const QString &iconName, const QStringList &searchPaths) const;
     mutable QHash <QString, XdgIconTheme> themeList;
     bool m_followColorScheme = true;
+    bool m_dashFallback = true;
 };
 
 #endif // QT_NO_ICON


### PR DESCRIPTION
Add XdgIconLoader::dashFallback XdgIconLoader::setDashFallback.
Allows the caller to decide whether to use "dash fallback" behavior,
when finding some type of icon, often expects to do dash fallback
operation, such as
https://specifications.freeDesktop.org/icon-naming-spec/icon-naming-spec
-latest.html icon of the MimeTypes class mentioned.