### PR TITLE
Fixed config file name with empty `XDG_CURRENT_DESKTOP`

### DIFF
--- a/src/qtxdg/xdgdefaultapps.cpp
+++ b/src/qtxdg/xdgdefaultapps.cpp
@@ -80,7 +80,7 @@ static QString qtxdgConfigFilename()
     // first find the DE's qtxdg.conf file
     QByteArray qtxdgConfig("qtxdg");
     QList<QByteArray> desktopsList = qgetenv("XDG_CURRENT_DESKTOP").toLower().split(':');
-    if (!desktopsList.isEmpty()) {
+    if (!desktopsList.isEmpty() && !desktopsList.at(0).isEmpty()) {
         qtxdgConfig = desktopsList.at(0) + '-' + qtxdgConfig;
     }
 


### PR DESCRIPTION
Previously, it started with dash.

See https://github.com/lxqt/libfm-qt/pull/766 for a similar fix.