### PR TITLE
Fixed can't get icon when installing wine app

### DIFF
--- a/src/xdgiconloader/xdgiconloader.cpp
+++ b/src/xdgiconloader/xdgiconloader.cpp
@@ -416,7 +416,7 @@ QThemeIconInfo XdgIconLoader::findIconHelper(const QString &themeName,
             // Try to reduce the amount of subDirs by looking in the GTK+ cache in order to save
             // a massive amount of file stat (especially if the icon is not there)
             auto cache = theme.m_gtkCaches.at(i);
-            if (cache->isValid() || cache->reValid(true)) {
+            if (cache->reValid(true) || cache->isValid()) {
                 const auto result = cache->lookup(iconNameFallback);
                 if (cache->isValid()) {
                     const QVector<QIconDirInfo> subDirsCopy = subDirs;


### PR DESCRIPTION
When cache->isValid() returns true, cache->reValid(true) will no longer
be executed, resulting in gtkCachesWatcher->addPath no longer adding
monitoring files, which cannot be monitored when icon-theme.cache changes.

Even with 3.3.1, this fix still solves the problem