### PR TITLE
Workaround for random lack of icons in newly installed apps

### DIFF
--- a/src/xdgiconloader/xdgiconloader.cpp
+++ b/src/xdgiconloader/xdgiconloader.cpp
@@ -414,11 +414,11 @@ QThemeIconInfo XdgIconLoader::findIconHelper(const QString &themeName,
             QVector<QIconDirInfo> subDirs = theme.keyList();
 
             // Try to reduce the amount of subDirs by looking in the GTK+ cache in order to save
-            // a massive amount of file stat (especially if the icon is not there)
+            // a massive amount of file stat
             auto cache = theme.m_gtkCaches.at(i);
             if (cache->isValid() || cache->reValid(true)) {
                 const auto result = cache->lookup(iconNameFallback);
-                if (cache->isValid()) {
+                if (cache->isValid() && !result.isEmpty()) {
                     const QVector<QIconDirInfo> subDirsCopy = subDirs;
                     subDirs.clear();
                     subDirs.reserve(result.count());


### PR DESCRIPTION
Workaround for random lack of icons in newly installed apps

This patch is a workaround for a random problem whose cause should be outside `xdgiconloader/xdgiconloader.cpp` — `xdgiconloader.cpp` seems correct to me in its original form.

The source of the problem is unknown to me, but it makes newly installed apps have `application-x-executable` as their icons in Main Menu.

The patch is a compromise: it consults GTK icon cache if valid; otherwise, it'll revalidate it and search in the directory hierarchy if the icon isn't found in it — which is the whole point of the patch.

IMHO, a DE that can't show the icons of newly installed apps has a serious UX issue.

Closes https://github.com/lxqt/libqtxdg/issues/226

EDIT: Changed the description a litttle.