### PR TITLE
Fixed file association with symlink desktop entries

### DIFF
--- a/src/qtxdg/xdgdesktopfile.cpp
+++ b/src/qtxdg/xdgdesktopfile.cpp
@@ -750,9 +750,8 @@ bool XdgDesktopFile::load(const QString& fileName)
 {
     d->clear();
     if (fileName.startsWith(QDir::separator())) { // absolute path
-        QFileInfo f(fileName);
-        if (f.exists())
-            d->mFileName = f.canonicalFilePath();
+        if (QFileInfo::exists(fileName))
+            d->mFileName = fileName;
         else
             return false;
     } else { // relative path
@@ -1482,13 +1481,13 @@ QString findDesktopFile(const QString& dirName, const QString& desktopName)
     QFileInfo fi(dir, desktopName);
 
     if (fi.exists())
-        return fi.canonicalFilePath();
+        return fi.absoluteFilePath();
 
     // Working recursively ............
     const QFileInfoList dirs = dir.entryInfoList(QStringList(), QDir::Dirs | QDir::NoDotAndDotDot);
     for (const QFileInfo &d : dirs)
     {
-        QString cn = d.canonicalFilePath();
+        QString cn = d.absoluteFilePath();
         if (dirName != cn)
         {
             QString f = findDesktopFile(cn, desktopName);

--- a/src/qtxdg/xdgmenuapplinkprocessor.cpp
+++ b/src/qtxdg/xdgmenuapplinkprocessor.cpp
@@ -190,7 +190,7 @@ void XdgMenuApplinkProcessor::findDesktopFiles(const QString& dirName, const QSt
     for (const QFileInfo &file : files)
     {
         auto f = std::make_unique<XdgDesktopFile>();
-        if (f->load(file.canonicalFilePath()) && f->isValid())
+        if (f->load(file.absoluteFilePath()) && f->isValid())
             mAppFileInfoHash.insert(prefix + file.fileName(), new XdgMenuAppFileInfo(std::move(f), prefix + file.fileName(), this));
     }
 
@@ -199,7 +199,7 @@ void XdgMenuApplinkProcessor::findDesktopFiles(const QString& dirName, const QSt
     const QFileInfoList dirs = dir.entryInfoList(QStringList(), QDir::Dirs | QDir::NoDotAndDotDot);
     for (const QFileInfo &d : dirs)
     {
-        QString dn = d.canonicalFilePath();
+        QString dn = d.absoluteFilePath();
         if (dn != dirName)
         {
             findDesktopFiles(dn, QString::fromLatin1("%1%2-").arg(prefix, d.fileName()));


### PR DESCRIPTION
Previously, the (final) targets of symlink desktop entries were loaded and failed to meet the requirements of mime-type association. The patch solves the problem by loading the symlinks themselves.

I didn't find any side effect in the code or in practice. The only difference I've found is that, if a menu item corresponding to a symlink desktop entry is dragged and dropped, it'll be created as a symlink, not as its target — which isn't a problem and seems more natural to me.

Fixes https://github.com/lxqt/libqtxdg/issues/287 and closes https://github.com/lxqt/lxqt-config/issues/897