### PR TITLE
Use QImageReader instead of QSvgRender for XdgIconLoader

### DIFF
--- a/src/xdgiconloader/xdgiconloader.cpp
+++ b/src/xdgiconloader/xdgiconloader.cpp
@@ -53,7 +53,7 @@
 #include <QImageReader>
 #include <QXmlStreamReader>
 #include <QFileSystemWatcher>
-#include <QSvgRenderer>
+#include <QBuffer>
 
 #include <private/qhexstring_p.h>
 
@@ -829,12 +829,12 @@ QPixmap ScalableEntry::pixmap(const QSize &size, QIcon::Mode mode, QIcon::State 
         pm = QPixmap(icnSize, icnSize);
         pm.fill(Qt::transparent);
 
-        QSvgRenderer renderer;
-        if (renderer.load(filename))
-        {
+        QImageReader imageReader(filename);
+        if (imageReader.canRead()) {
+            imageReader.setScaledSize(QSize(icnSize, icnSize));
             QPainter p;
             p.begin(&pm);
-            renderer.render(&p, QRect(0, 0, icnSize, icnSize));
+            p.drawImage(0, 0, imageReader.read());
             p.end();
         }
 
@@ -928,11 +928,14 @@ QPixmap ScalableFollowsColorEntry::pixmap(const QSize &size, QIcon::Mode mode, Q
 
             if (!svgBuffer.isEmpty())
             {
-                QSvgRenderer renderer;
-                renderer.load(svgBuffer);
+                QBuffer buffer;
+                buffer.setData(svgBuffer);
+                buffer.open(QIODevice::ReadOnly);
+                QImageReader imageReader(&buffer);
+                imageReader.setScaledSize(QSize(icnSize, icnSize));
                 QPainter p;
                 p.begin(&pm);
-                renderer.render(&p, QRect(0, 0, icnSize, icnSize));
+                p.drawImage(0, 0, imageReader.read());
                 p.end();
             }
         }


### PR DESCRIPTION
QSvgRender itself only support SVG 1.2 Tiny for rendering so SVGs that more complex might not able to rendered properly. Thus, some DE like [KDE](https://github.com/KDE/kiconthemes/commit/5666c0c46e913fecbe2b41157f241685f126ab30) and DDE provides their own Qt icon engine and registered them as for SVG icons, and seems that causes libqtxdg have issues, so https://github.com/lxqt/libqtxdg/pull/247 was there.

But user or DE might still want to install or provide Qt image formats plugins for better SVG files/icons rendering, using QSvgRender will stop the Qt image formats plugin from being used.

Using QImageReader will still allow us avoiding the usage of Qt icon engines, but kept the ability to make Qt image formats plugin to work properly.

-----------

This patch originally provided by @zccrs

This patch is intended to address the issue that incorrect SVG icon rendering under Archlinux DDE, and can be tested by installing DDE under Archlinux, then install `deepin-icon-theme`, `deepin-camera` and browse the deepin-camera's icon from launcher (the start menu thing). Since that step might be complicated if you don't want to install Archlinux or DDE, you can also https://github.com/BLumia/qt-icon-engine-tool and use the following attachment SVG image for testing (image extracted from the bloom theme provided by `deepin-icon-theme`):

![deepin-camera](https://user-images.githubusercontent.com/10095765/221340904-370c6981-cd41-4e84-8c97-2f609246e8cc.svg)
