### PR TITLE
Add support for translations defined via X-Ubuntu-Gettext-Domain

### DIFF
--- a/src/qtxdg/xdgdesktopfile.cpp
+++ b/src/qtxdg/xdgdesktopfile.cpp
@@ -920,7 +920,22 @@ QString XdgDesktopFile::localizedKey(const QString& key) const
 
 QVariant XdgDesktopFile::localizedValue(const QString& key, const QVariant& defaultValue) const
 {
-    return value(localizedKey(key), defaultValue);
+    // If the file is translated via gettext, override locally-defined translations
+    if (contains(QLatin1String("X-Ubuntu-Gettext-Domain")))
+    {
+        QString domain = value(QLatin1String("X-Ubuntu-Gettext-Domain")).toString();
+        QString val = value(key, defaultValue).toString().trimmed();
+        if (!val.isEmpty()) {
+            QByteArray _domain = domain.toUtf8();
+            QByteArray _val = val.toUtf8();
+            char *translated = dgettext(_domain.constData(), _val.constData());
+            return QVariant(QString::fromUtf8(translated));
+        } else {
+            return QVariant();
+        }
+    } else {
+        return value(localizedKey(key), defaultValue);
+    }
 }
 
 


### PR DESCRIPTION
I'm submitting this upstream to be collaborative, but I can also understand why this could stay as a downstream patch. Not my decision, just figured I'd be nice and submit it. :)

The Lubuntu Global Team pointed out that some packages with Launchpad-based translations aren't being translated correctly in the LXQt menu. Further discussion can be found [here](https://discourse.lubuntu.me/t/problems-with-the-translations-of-desktop-launchers/4051).

In the interest of non-English users, we'll be carrying this in Lubuntu 23.04. If you guys have any code feedback, please let me know.

Thanks!