### PR TITLE
qtxdg-iconfinder: Fix an FTBFS

### DIFF
--- a/util/qtxdg-iconfinder.cpp
+++ b/util/qtxdg-iconfinder.cpp
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
         const auto info = XdgIconLoader::instance()->loadIcon(iconName);
         qint64 elapsed = t.elapsed();
         const auto icon = info.iconName;
-        const auto entries = info.entries;
+        const auto &entries = info.entries;
 
         std::cout << qPrintable(iconName) <<
             qPrintable(QString::fromLatin1(":")) << qPrintable(icon) <<


### PR DESCRIPTION
Adapt to:
using QThemeIconEntries = std::vector<std::unique_ptr<QIconLoaderEngineEntry>>;