### PR TITLE
Added `plasma-applications.menu` to fallback menu files

### DIFF
--- a/src/qtxdg/xdgmenu.cpp
+++ b/src/qtxdg/xdgmenu.cpp
@@ -666,6 +666,7 @@ QString XdgMenu::getMenuFileName(const QString& baseName)
     // rest files ordered by priority (descending)
     wellKnownFiles << QLatin1String("kde4-applications.menu");
     wellKnownFiles << QLatin1String("kde-applications.menu");
+    wellKnownFiles << QLatin1String("plasma-applications.menu");
     wellKnownFiles << QLatin1String("gnome-applications.menu");
     wellKnownFiles << QLatin1String("lxde-applications.menu");
 


### PR DESCRIPTION
Recently, `applications.menu` (belonging to `kservice5`) was removed and `plasma-applications.menu` (belonging to `plasma-workspace`) was added. Hence adding the latter to the fallback list.