### PR TITLE
cmake: fix build with Qt 6.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,10 @@ find_package(Qt6 ${QT_MINIMUM_VERSION} CONFIG REQUIRED Widgets Svg Xml DBus)
 find_package(GLIB ${GLIB_MINIMUM_VERSION} REQUIRED COMPONENTS gobject gio gio-unix)
 find_package(XTerm)
 
+if (Qt6Gui_VERSION VERSION_GREATER_EQUAL "6.10.0")
+    find_package(Qt6GuiPrivate ${QT_MINIMUM_VERSION} REQUIRED)
+endif()
+
 include(GNUInstallDirs)             # Standard directories for installation
 include(CMakePackageConfigHelpers)
 include(GenerateExportHeader)

--- a/src/qtxdg/CMakeLists.txt
+++ b/src/qtxdg/CMakeLists.txt
@@ -78,6 +78,8 @@ add_library(${QTXDGX_LIBRARY_NAME} SHARED
 )
 
 target_link_libraries(${QTXDGX_LIBRARY_NAME}
+    PRIVATE
+        Qt6::GuiPrivate
     PUBLIC
         ${QTX_LIBRARIES}
         ${QTXDGX_ICONLOADER_LIBRARY_NAME}

--- a/src/xdgiconloader/CMakeLists.txt
+++ b/src/xdgiconloader/CMakeLists.txt
@@ -50,6 +50,8 @@ target_include_directories(${QTXDGX_ICONLOADER_LIBRARY_NAME}
 )
 
 target_link_libraries(${QTXDGX_ICONLOADER_LIBRARY_NAME}
+    PRIVATE
+        Qt6::GuiPrivate
     PUBLIC
         Qt6::Gui
         Qt6::Svg

--- a/src/xdgiconloader/plugin/CMakeLists.txt
+++ b/src/xdgiconloader/plugin/CMakeLists.txt
@@ -11,6 +11,8 @@ target_compile_definitions(${QTXDGX_ICONENGINEPLUGIN_LIBRARY_NAME}
         "QT_NO_KEYWORDS"
 )
 target_link_libraries(${QTXDGX_ICONENGINEPLUGIN_LIBRARY_NAME}
+    PRIVATE
+        Qt6::GuiPrivate
     PUBLIC
         Qt6::Gui
         "${QTXDGX_ICONLOADER_LIBRARY_NAME}"


### PR DESCRIPTION
The 'Qt6FooPrivate' targets have been split into separate CMake files
in Qt 6.9, and require a 'find_package(Qt6FooPrivate)' call starting
with Qt 6.10.

See also: https://bugreports.qt.io/browse/QTBUG-87776
