### PR TITLE
Add State Home directory implementation

### DIFF
--- a/src/qtxdg/xdgdirs.cpp
+++ b/src/qtxdg/xdgdirs.cpp
@@ -367,3 +367,41 @@ QStringList XdgDirs::autostartDirs(const QString &postfix)
     cleanAndAddPostfix(dirs, postfix);
     return dirs;
 }
+
+
+QString XdgDirs::stateHome(bool createDir)
+{
+    QString d = qEnvironmentVariable("XDG_STATE_HOME");
+
+    // All paths set in the environment variables must be absolute
+    // Relative paths should consider the path invalid and ignore it
+    if (!d.startsWith(u'/'))
+        d.clear();
+
+    if (d.isEmpty())
+        d = QDir::homePath() + "/.local/state"_L1;
+
+    if (createDir)
+        return createDirectory(d);
+
+    return d;
+}
+
+QString XdgDirs::stateHome(const QString &postfix, bool createDir)
+{
+    QString d = stateHome(createDir);
+    if (d.isEmpty())
+        return QString();
+
+    if (postfix.isEmpty())
+        return d;
+
+    fixBashShortcuts(d);
+    removeEndingSlash(d);
+    const QString dir = d.append(handlePostfix(postfix));
+
+    if (createDir)
+        return createDirectory(dir);
+
+    return dir;
+}

--- a/src/qtxdg/xdgdirs.h
+++ b/src/qtxdg/xdgdirs.h
@@ -151,6 +151,19 @@ public:
       * @sa autostartHome()
       */
      static QStringList autostartDirs(const QString &postfix = QString());
+
+     /*! @brief Returns a directory location where user-specific application state data files should be written.
+      * If $XDG_STATE_HOME is either not set or empty, a default equal to $HOME/.local/state should be used.
+      * If @i createDir is true the resultig dir will be created. If the resulting dir cannot be createds an empty string is returned.
+      */
+     static QString stateHome(bool createDir = true);
+
+     /*! @brief Returns a directory location where user-specific application state data files should be written.
+      * If $XDG_STATE_HOME is either not set or empty, a default equal to $HOME/.local/state should be used.
+      * If @i postfix is not empty it will be appended to the XDG_STATE_HOME.
+      * If @i createDir is true the resultig dir will be created. If the resulting dir cannot be createds an empty string is returned.
+      */
+     static QString stateHome(const QString &postfix, bool createDir = true);
 };
 
 #endif // QTXDG_XDGDIRS_H

--- a/test/tst_xdgdirs.cpp
+++ b/test/tst_xdgdirs.cpp
@@ -33,6 +33,7 @@
 #include <QFileInfo>
 #include <QRandomGenerator>
 #include <QTest>
+#include <QFileInfo>
 #include <QTemporaryDir>
 
 using namespace Qt::Literals::StringLiterals;
@@ -67,6 +68,7 @@ private Q_SLOTS:
     void testAutostartHome();
     void testAutostartDirs();
     void testNonWritableLocations();
+    void testStateHome();
 
 private:
     void setDefaultLocations();
@@ -89,6 +91,9 @@ private:
 
     QDir m_nonWritableRoot;
     QString m_configHomeNonWritable;
+
+    QString m_stateHome;
+    QTemporaryDir m_stateHomeTemp;
 };
 
 void tst_xdgdirs::initTestCase()
@@ -117,6 +122,7 @@ void tst_xdgdirs::setDefaultLocations()
     qputenv("XDG_DATA_HOME", QByteArray());
     qputenv("XDG_DATA_DIRS", QByteArray());
     qputenv("XDG_CACHE_HOME", QByteArray());
+    qputenv("XDG_STATE_HOME", QByteArray());
 }
 
 void tst_xdgdirs::setCustomLocations()
@@ -126,12 +132,13 @@ void tst_xdgdirs::setCustomLocations()
     m_dataHome = m_dataHomeTemp.path();
     m_dataDirs = m_dataDirsTemp.path();
     m_cacheHome = m_cacheHomeTemp.path();
+    m_stateHome = m_stateHomeTemp.path();
     qputenv("XDG_CONFIG_HOME", QFile::encodeName(m_configHome));
     qputenv("XDG_CONFIG_DIRS", QFile::encodeName(m_configDirs));
     qputenv("XDG_DATA_HOME", QFile::encodeName(m_dataHome));
     qputenv("XDG_DATA_DIRS", QFile::encodeName(m_dataDirs));
     qputenv("XDG_CACHE_HOME", QFile::encodeName(m_cacheHome));
-
+    qputenv("XDG_STATE_HOME", QFile::encodeName(m_stateHome));
 }
 
 void tst_xdgdirs::setNonWritableLocations()
@@ -146,6 +153,7 @@ void tst_xdgdirs::setNonWritableLocations()
     qputenv("XDG_CONFIG_HOME", QFile::encodeName(m_configHomeNonWritable));
     qputenv("XDG_DATA_HOME", QFile::encodeName(m_configHomeNonWritable));
     qputenv("XDG_CACHE_HOME", QFile::encodeName(m_configHomeNonWritable));
+    qputenv("XDG_STATE_HOME", QFile::encodeName(m_configHomeNonWritable));
 }
 
 void tst_xdgdirs::testDataHome()
@@ -290,6 +298,20 @@ void tst_xdgdirs::testNonWritableLocations()
     QCOMPARE(XdgDirs::dataHome(true), QString());
     QCOMPARE(XdgDirs::cacheHome(true), QString());
     QCOMPARE(XdgDirs::autostartHome(true), QString());
+
+    QCOMPARE(XdgDirs::stateHome(true), QString());
+    QCOMPARE(XdgDirs::stateHome("appName"_L1), QString());
+}
+
+void tst_xdgdirs::testStateHome()
+{
+    setDefaultLocations();
+    const QString stateHome = XdgDirs::stateHome();
+    QCOMPARE(stateHome, QDir::homePath() + "/.local/state"_L1);
+
+    setCustomLocations();
+    const QString stateHomeCustom = XdgDirs::stateHome();
+    QCOMPARE(stateHomeCustom, m_stateHome);
 }
 
 QTEST_APPLESS_MAIN(tst_xdgdirs)


### PR DESCRIPTION
There is a single base directory relative to which user-specific state data should be written. This directory is defined by the environment variable $XDG_STATE_HOME.

$XDG_STATE_HOME defines the base directory relative to which user-specific state files should be stored. If $XDG_STATE_HOME is either not set or empty, a default equal to $HOME/.local/state should be used.

The $XDG_STATE_HOME contains state data that should persist between (application) restarts, but that is not important or portable enough to the user that it should be stored in $XDG_DATA_HOME. It may contain:

    actions history (logs, history, recently used files, …)

    current state of the application that can be reused on a restart
        (view, layout, open files, undo history, …)

Reference: https://specifications.freedesktop.org/basedir/latest/#index