### PR TITLE
Fix NotShowIn handling

### DIFF
--- a/src/qtxdg/xdgdesktopfile.cpp
+++ b/src/qtxdg/xdgdesktopfile.cpp
@@ -1381,7 +1381,7 @@ bool XdgDesktopFile::isSuitable(bool excludeHidden, const QString &environment) 
     if (environment.isEmpty())
         env = QString::fromLocal8Bit(qgetenv("XDG_CURRENT_DESKTOP").toLower()).split(u':');
     else {
-        env.push_back(environment.toLower());
+        env = environment.toLower().split(u':');
     }
 
     const auto has_env_intersection = [&env] (const QStringList & values) -> bool {

--- a/src/qtxdg/xdgmenuapplinkprocessor.cpp
+++ b/src/qtxdg/xdgmenuapplinkprocessor.cpp
@@ -106,19 +106,9 @@ void XdgMenuApplinkProcessor::step2()
 
         XdgDesktopFile* file = fileInfo->desktopFile();
 
-        bool show = false;
         QStringList envs = mMenu->environments();
-        const int N = envs.size();
-        for (int i = 0; i < N; ++i)
-        {
-            if (file->isShown(envs.at(i)))
-            {
-                show = true;
-                break;
-            }
-        }
 
-        if (!show)
+        if (!file->isShown(envs.join(u':')))
             continue;
 
         QDomElement appLink = doc.createElement("AppLink"_L1);


### PR DESCRIPTION
This fixes the problem that setting `NotShowIn=LXQt` does not work.

This happened because the panel passes "X-LXQT" and "LXQt" values as environments, and these environments were checked separately. But to honor the `NotShowIn` value, it needs to be checked at once.