### PR TITLE
update fsf address

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -3,7 +3,7 @@
                        Version 2.1, February 1999
 
  Copyright (C) 1991, 1999 Free Software Foundation, Inc.
-	51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/src/qtxdg/xdgaction.h
+++ b/src/qtxdg/xdgaction.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/src/qtxdg/xdgautostart.h
+++ b/src/qtxdg/xdgautostart.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/src/qtxdg/xdgdesktopfile.h
+++ b/src/qtxdg/xdgdesktopfile.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/src/qtxdg/xdgdirs.h
+++ b/src/qtxdg/xdgdirs.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/src/qtxdg/xdgicon.h
+++ b/src/qtxdg/xdgicon.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/src/qtxdg/xdgmenu.h
+++ b/src/qtxdg/xdgmenu.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/src/qtxdg/xdgmenuwidget.h
+++ b/src/qtxdg/xdgmenuwidget.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/src/qtxdg/xmlhelper.h
+++ b/src/qtxdg/xmlhelper.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 


### PR DESCRIPTION
See https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html for the most current published address

On rpm based systems, when building, the old fsf address throws an Error in rpmlint.

This PR doesn't change any functionality, it's completely administrative.